### PR TITLE
[connect-wallet] Add `Playground` story for Connect Wallet package

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install && yarn build
 
       - name: Publish to Chromatic
         run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,6 +6,10 @@ name: 'Chromatic'
 # Event for the workflow
 on: push
 
+env:
+  # 7 GiB by default on GitHub, setting this to 16 GiB
+  NODE_OPTIONS: --max-old-space-size=16384
+
 # List of jobs
 jobs:
   chromatic-deployment:

--- a/packages/connect-wallet/package.json
+++ b/packages/connect-wallet/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.1",
     "@shopify/gate-context-client": "*",
+    "@storybook/react": "^6.5.13",
     "framer-motion": "^8.5.0",
     "i18next": "^22.4.9",
     "qrcode": "^1.5.1",

--- a/packages/connect-wallet/src/components/Playground/Playground.stories.tsx
+++ b/packages/connect-wallet/src/components/Playground/Playground.stories.tsx
@@ -1,0 +1,48 @@
+import {WagmiConfig, configureChains, createClient} from 'wagmi';
+import {mainnet} from 'wagmi/chains';
+import {publicProvider} from 'wagmi/providers/public';
+
+import {ConnectWalletProvider} from '../../providers/ConnectWalletProvider';
+import {getDefaultConnectors} from '../../connectors/getDefaultConnectors';
+import {ConnectButton} from '..';
+
+const PlaygroundStory = {
+  title: 'Connect Wallet',
+  component: WagmiConfig,
+  argTypes: {
+    wallets: {
+      control: {type: 'select'},
+      options: ['Ethereum'],
+    },
+  },
+};
+
+export default PlaygroundStory;
+
+const Template = ({wallets}: {wallets: 'Ethereum' | 'Solana'}) => {
+  const chains = wallets === 'Ethereum' ? [mainnet] : [];
+  const {provider, webSocketProvider} = configureChains(chains, [
+    publicProvider(),
+  ]);
+
+  const {connectors} = getDefaultConnectors({chains});
+
+  const client = createClient({
+    autoConnect: true,
+    connectors,
+    provider,
+    webSocketProvider,
+  });
+
+  return (
+    <WagmiConfig client={client}>
+      <ConnectWalletProvider chains={chains}>
+        <ConnectButton />
+      </ConnectWalletProvider>
+    </WagmiConfig>
+  );
+};
+
+export const Playground = Template.bind({
+  wallets: 'Ethereum',
+});

--- a/packages/connect-wallet/src/components/index.ts
+++ b/packages/connect-wallet/src/components/index.ts
@@ -1,1 +1,2 @@
 export {Modal} from './Modal';
+export {ConnectButton} from './ConnectButton/ConnectButton';


### PR DESCRIPTION
## What is the context for these changes?

This PR adds a Playground to Storybook for the `Connect Wallet` package. The idea is to use the tools Storybook provides to enhance the development tools. 

## Demonstration
<img width="1512" alt="16-23-2kvc9-n09dk" src="https://user-images.githubusercontent.com/8977776/219500748-64e82bf1-091f-4238-afc9-f17ca769f9e8.png">



<!-- ℹ️ Delete the following for small / trivial changes -->

## How can this be tophatted?
Can be 🎩 in https://639b1f308693132693d9b82c-cafbriamhq.chromatic.com/?path=/story/connect-wallet--playground&args=wallets:Ethereum

## 🎩 Checklist
<!--
  If any of the following are not relevant you may strike them out using the ~ character before and after the checklist item's label.
-->

- [x] Tested on mobile
- [x] Tested on multiple browsers
- [x] Tested for accessibility
- [x] Updated relevant documentation for the changes (if necessary)
