### PR TITLE
[chore] :recycle: Refactor onConnect listener creation to a util function

### DIFF
--- a/packages/connect-wallet/src/hooks/useConnectWallet/useConnectWalletCallbacks.ts
+++ b/packages/connect-wallet/src/hooks/useConnectWallet/useConnectWalletCallbacks.ts
@@ -1,58 +1,24 @@
-import {isAnyOf} from '@reduxjs/toolkit';
-import {useContext, useEffect} from 'react';
+import {useEffect} from 'react';
 
-import {ConnectWalletContext} from '../../providers/ConnectWalletProvider';
-import {
-  addWallet,
-  removeWallet,
-  setActiveWallet,
-  validatePendingWallet,
-} from '../../slices/walletSlice';
+import {buildOnConnectMiddleware} from '../../middleware/onConnectMiddleware';
+import {removeWallet} from '../../slices/walletSlice';
 import {addListener} from '../../store/listenerMiddleware';
-import {Wallet} from '../../types/wallet';
 import {useAppDispatch} from '../useAppState';
 
 import {useConnectWalletProps} from './types';
 
 export const useConnectWalletCallbacks = (props?: useConnectWalletProps) => {
   const {onConnect, onDisconnect} = props || {};
-  const {requireSignature} = useContext(ConnectWalletContext);
   const dispatch = useAppDispatch();
 
   // Add the onConnect callback listeners.
   useEffect(() => {
-    const unsubscribeToOnConnectListener = dispatch(
-      addListener({
-        matcher: isAnyOf(
-          addWallet,
-          validatePendingWallet.fulfilled,
-          setActiveWallet,
-        ),
-        effect: (action, state) => {
-          let walletToDispatch: Wallet | undefined;
+    const listener = buildOnConnectMiddleware(({wallet}) => {
+      onConnect?.(wallet);
+    });
 
-          if (action.type === 'wallet/validatePendingWallet/fulfilled') {
-            const signatureResponse = action.meta.arg;
-            const {address, signature} = signatureResponse;
-
-            const {connectedWallets} = state.getState().wallet;
-            walletToDispatch = connectedWallets.find(
-              (wallet) =>
-                wallet.address === address && wallet.signature === signature,
-            );
-          } else {
-            walletToDispatch = action.payload;
-          }
-
-          if (walletToDispatch) {
-            onConnect?.(walletToDispatch);
-          }
-        },
-      }),
-    );
-
-    return unsubscribeToOnConnectListener;
-  }, [dispatch, onConnect, requireSignature]);
+    return dispatch(listener);
+  }, [dispatch, onConnect]);
 
   // Add the onDisconnect callback listeners.
   useEffect(() => {

--- a/packages/connect-wallet/src/hooks/useMiddleware.ts
+++ b/packages/connect-wallet/src/hooks/useMiddleware.ts
@@ -1,0 +1,135 @@
+import {useEffect} from 'react';
+import {useAccount} from 'wagmi';
+
+import {buildOnConnectMiddleware} from '../middleware/onConnectMiddleware';
+import {
+  addWallet,
+  attributeOrder,
+  setActiveWallet,
+  setPendingWallet,
+} from '../slices/walletSlice';
+import {addListener} from '../store/listenerMiddleware';
+import {OrderAttributionMode} from '../types/orderAttribution';
+import {SignatureResponse, Wallet} from '../types/wallet';
+
+import {useAppDispatch, useAppSelector} from './useAppState';
+
+interface UseMiddlewareProps {
+  orderAttributionMode: OrderAttributionMode;
+  requestSignature: (wallet: Wallet) => Promise<SignatureResponse | undefined>;
+  requireSignature?: boolean;
+}
+
+export const useMiddleware = ({
+  orderAttributionMode,
+  requestSignature,
+  requireSignature,
+}: UseMiddlewareProps) => {
+  const dispatch = useAppDispatch();
+  const {connectedWallets, pendingConnector} = useAppSelector(
+    (state) => state.wallet,
+  );
+
+  useAccount({
+    onConnect: ({address, connector, isReconnected}) => {
+      if (!address) {
+        return;
+      }
+
+      const reconnectedWallet: Wallet | undefined = connectedWallets.find(
+        (wallet) => wallet.address === address,
+      );
+
+      if (requireSignature) {
+        /**
+         * Check if the wallet has already signed. If so, we can set
+         * the active wallet and not require a new signature.
+         */
+        if (isReconnected && reconnectedWallet?.signature) {
+          return dispatch(setActiveWallet(reconnectedWallet));
+        }
+
+        /**
+         * Check to ensure we have connector data before proceeding. We
+         * need connector for injected connectors such as Coinbase Wallet
+         * and MetaMask. Otherwise, utilize pendingConnector value.
+         */
+        if (!pendingConnector && !connector) {
+          return;
+        }
+
+        const wallet: Wallet = {
+          address,
+          connectorId: pendingConnector?.id || connector?.id,
+          connectorName: pendingConnector?.name || connector?.name,
+        };
+
+        return dispatch(setPendingWallet(wallet));
+      }
+
+      /**
+       * If we don't require a signature and we have a reconnected
+       * wallet then we can set the active wallet.
+       */
+      if (reconnectedWallet) {
+        return dispatch(setActiveWallet(reconnectedWallet));
+      }
+
+      // Exit if we don't have pendingConnector information.
+      if (!pendingConnector) {
+        return;
+      }
+
+      // This means that the user just connected their wallet.
+      dispatch(
+        addWallet({
+          address,
+          connectorId: pendingConnector.id,
+          connectorName: pendingConnector.name,
+        }),
+      );
+    },
+  });
+
+  /**
+   * Pending wallet listener
+   *
+   * Utilized to request signature verification.
+   */
+  useEffect(() => {
+    if (requireSignature) {
+      return dispatch(
+        addListener({
+          actionCreator: setPendingWallet,
+          effect: (action, _) => {
+            const wallet = action.payload;
+
+            if (!wallet) {
+              return;
+            }
+
+            requestSignature(wallet);
+          },
+        }),
+      );
+    }
+  }, [dispatch, requestSignature, requireSignature]);
+
+  /**
+   * onConnect listener (internal)
+   *
+   * This listener will run order attribution functionality.
+   */
+  useEffect(() => {
+    const listener = buildOnConnectMiddleware(({state, wallet}) => {
+      state.dispatch(
+        attributeOrder({
+          orderAttributionMode,
+          wallet,
+        }),
+      );
+    });
+
+    return dispatch(listener);
+  }, [dispatch, orderAttributionMode]);
+};

--- a/packages/connect-wallet/src/middleware/onConnectMiddleware.test.ts
+++ b/packages/connect-wallet/src/middleware/onConnectMiddleware.test.ts
@@ -1,0 +1,73 @@
+import {
+  addWallet,
+  setActiveWallet,
+  setPendingWallet,
+  validatePendingWallet,
+} from '../slices/walletSlice';
+import {store} from '../test/configureStore';
+import {
+  INVALID_SIGNATURE_RESPONSE,
+  VALID_SIGNATURE_RESPONSE,
+} from '../test/fixtures/signature';
+import {DEFAULT_WALLET} from '../test/fixtures/wallet';
+import {ConnectWalletError} from '../utils/error';
+
+import {buildOnConnectMiddleware} from './onConnectMiddleware';
+
+describe('onConnectMiddleware', () => {
+  const effectFn = jest.fn();
+
+  beforeEach(() => {
+    const listener = buildOnConnectMiddleware(({wallet}) => effectFn(wallet));
+
+    store.dispatch(listener);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('addWallet', () => {
+    it('runs the effect when addWallet is dispatched', () => {
+      store.dispatch(addWallet(DEFAULT_WALLET));
+
+      expect(effectFn).toHaveBeenCalledWith(DEFAULT_WALLET);
+    });
+  });
+
+  describe('setActiveWallet', () => {
+    it('runs the effect when setActiveWallet payload is a wallet', () => {
+      store.dispatch(setActiveWallet(DEFAULT_WALLET));
+
+      expect(effectFn).toHaveBeenCalledWith(DEFAULT_WALLET);
+    });
+
+    it('does not run the effect when setActiveWallet payload is undefined', () => {
+      store.dispatch(setActiveWallet(undefined));
+
+      expect(effectFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validatePendingWallet', () => {
+    it('runs the effect when validatePendingWallet payload is a valid signed message', async () => {
+      store.dispatch(setPendingWallet(DEFAULT_WALLET));
+
+      await store.dispatch(validatePendingWallet(VALID_SIGNATURE_RESPONSE));
+
+      expect(effectFn).toHaveBeenCalledWith(
+        expect.objectContaining({...DEFAULT_WALLET}),
+      );
+    });
+
+    it('does not run the effect when validatePendingWallet payload is not a valid signed message', async () => {
+      store.dispatch(setPendingWallet(DEFAULT_WALLET));
+
+      await expect(
+        store.dispatch(validatePendingWallet(INVALID_SIGNATURE_RESPONSE)),
+      ).rejects.toThrow(
+        new ConnectWalletError(
+          'Address that signed message does not match the connected address',
+        ),
+      );
+    });
+  });
+});

--- a/packages/connect-wallet/src/middleware/onConnectMiddleware.ts
+++ b/packages/connect-wallet/src/middleware/onConnectMiddleware.ts
@@ -1,0 +1,79 @@
+import {isAnyOf, ListenerEffect} from '@reduxjs/toolkit';
+
+import {
+  addWallet,
+  setActiveWallet,
+  validatePendingWallet,
+} from '../slices/walletSlice';
+import {AppDispatch, RootState} from '../store/configureStore';
+import {addListener} from '../store/listenerMiddleware';
+import {GuardedType} from '../types/generics';
+import {Wallet} from '../types/wallet';
+
+const matcher = isAnyOf(
+  addWallet,
+  setActiveWallet,
+  validatePendingWallet.fulfilled,
+);
+
+type ListenerEffectType = ListenerEffect<
+  GuardedType<typeof matcher>,
+  RootState,
+  AppDispatch
+>;
+
+type EffectAction = Parameters<ListenerEffectType>['0'];
+type EffectState = Parameters<ListenerEffectType>['1'];
+interface EffectCallbackProps {
+  state: EffectState;
+  wallet: Wallet;
+}
+
+const isWalletPayload = (
+  payload: EffectAction['payload'],
+): payload is Wallet => {
+  return payload !== undefined && 'address' in payload;
+};
+
+/**
+ * Creates a listener that runs an effect when:
+ * - a wallet is added via `addWallet`
+ * - a wallet is set as the activeWallet via `setActiveWallet`
+ * - a wallet is validated after signing via `validatePendingWallet`
+ *
+ * **NOTE**: The listener created is not automatically dispatched, this must be
+ * done manually.
+ *
+ * @param effect Callback function which receives a Wallet type.
+ */
+export const buildOnConnectMiddleware = (
+  effect?: ({state, wallet}: EffectCallbackProps) => void,
+) => {
+  return addListener({
+    matcher,
+    effect: (action, state) => {
+      let walletToDispatch: Wallet | undefined;
+
+      if (action.type === 'wallet/validatePendingWallet/fulfilled') {
+        // Since the `validatePendingWallet` action ran we know that we
+        // need to find the wallet from the list of connected wallets.
+        const signatureResponse = action.meta.arg;
+        const {address, signature} = signatureResponse;
+
+        const {connectedWallets} = state.getState().wallet;
+        walletToDispatch = connectedWallets.find(
+          (wallet) =>
+            wallet.address === address && wallet.signature === signature,
+        );
+      }
+
+      if (isWalletPayload(action.payload)) {
+        walletToDispatch = action.payload;
+      }
+
+      if (walletToDispatch) {
+        return effect?.({state, wallet: walletToDispatch});
+      }
+    },
+  });
+};

--- a/packages/connect-wallet/src/slices/walletSlice/walletSlice.test.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/walletSlice.test.ts
@@ -1,7 +1,9 @@
-import {SiweMessage} from 'siwe';
-
-import {SerializedConnector} from '../../types/connector';
-import {Wallet} from '../../types/wallet';
+import {DEFAULT_SERIALIZED_CONNECTOR} from '../../test/fixtures/connector';
+import {
+  INVALID_SIGNATURE_RESPONSE,
+  VALID_SIGNATURE_RESPONSE,
+} from '../../test/fixtures/signature';
+import {ALTERNATE_WALLET, DEFAULT_WALLET} from '../../test/fixtures/wallet';
 import {ConnectWalletError} from '../../utils/error';
 
 import {initialState, validatePendingWallet, walletSlice} from './walletSlice';
@@ -16,24 +18,6 @@ const {
 } = walletSlice.actions;
 
 const {getInitialState, reducer} = walletSlice;
-
-const DEFAULT_WALLET: Wallet = {
-  address: '0xc223594946c60217Ed53096eEC6C179964e536EB',
-  connectorId: 'metaMask',
-  connectorName: 'MetaMask',
-};
-
-const ALTERNATE_WALLET: Wallet = {
-  address: '0x5ea9681C3Ab9B5739810F8b91aE65EC47de62119',
-  connectorId: 'rainbow',
-  connectorName: 'Rainbow',
-};
-
-const DEFAULT_SERIALIZED_CONNECTOR: SerializedConnector = {
-  id: 'MetaMask',
-  name: 'MetaMask',
-  qrCodeSupported: false,
-};
 
 describe('walletSlice', () => {
   describe('addWallet', () => {
@@ -258,26 +242,10 @@ describe('walletSlice', () => {
   });
 
   describe('validatePendingWallet', () => {
-    const mockMessage = {
-      address: '0xc223594946c60217Ed53096eEC6C179964e536EB',
-      chainId: 1,
-      domain: 'localhost',
-      nonce: 'NAghkPB8sUBqz6s6W',
-      uri: 'http://localhost:5173',
-      version: '1',
-      issuedAt: '2023-01-30T16:24:40.222Z',
-    };
-
-    const message = new SiweMessage(mockMessage);
-    const validSignature =
-      '0x9ad835c2b18011cfb08798e856ab39b5d4595273c950fbc4f3b7703bbe7f7d026b556c0bff38829e686d9c495274aa2bde80bc06cfa97521b58f9ff9437d95b91b';
-
     it('does not manipulate state when state.pendingWallet is undefined', () => {
       const action = validatePendingWallet.fulfilled({valid: true}, '', {
         ...DEFAULT_WALLET,
-        message: JSON.stringify(message),
-        nonce: mockMessage.nonce,
-        signature: validSignature,
+        ...VALID_SIGNATURE_RESPONSE,
       });
 
       expect(() => reducer(initialState, action)).toThrow(
@@ -296,10 +264,7 @@ describe('walletSlice', () => {
         '',
         {
           ...DEFAULT_WALLET,
-          message: JSON.stringify(message),
-          nonce: mockMessage.nonce,
-          signature:
-            '0x0aa04781e381e84b1494d00245b5232ed9106377f541256bb504b75a04a9d2be2e895e4aab9cae3af41344e43ae7d5885202b66b2fa29d4c4443871cfaa575671c',
+          ...INVALID_SIGNATURE_RESPONSE,
         },
       );
 
@@ -318,9 +283,7 @@ describe('walletSlice', () => {
 
       const action = validatePendingWallet.fulfilled({valid: true}, '', {
         ...DEFAULT_WALLET,
-        message: JSON.stringify(message),
-        nonce: mockMessage.nonce,
-        signature: validSignature,
+        ...VALID_SIGNATURE_RESPONSE,
       });
 
       /**

--- a/packages/connect-wallet/src/store/listenerMiddleware.ts
+++ b/packages/connect-wallet/src/store/listenerMiddleware.ts
@@ -23,3 +23,5 @@ export const addListener = addRTKListener as RTKTypedAddListener<
   RootState,
   AppDispatch
 >;
+
+export type AddListenerOptions = Parameters<typeof addListener>[0];

--- a/packages/connect-wallet/src/test/configureStore.ts
+++ b/packages/connect-wallet/src/test/configureStore.ts
@@ -1,0 +1,32 @@
+// import {logger} from 'redux-logger';
+import {configureStore} from '@reduxjs/toolkit';
+
+import {initialState} from '../slices/walletSlice';
+import {rootReducer} from '../store/combineReducers';
+import {listenerMiddleware} from '../store/listenerMiddleware';
+
+const preloadedState = {
+  wallet: initialState,
+};
+
+export const store = configureStore({
+  reducer: rootReducer,
+  preloadedState,
+  middleware: (getDefaultMiddleware) => {
+    /**
+     * We prepend the listenerMiddleware here based on the comments
+     * in the middleware sample on the RTK docus.
+     *
+     * https://redux-toolkit.js.org/api/createListenerMiddleware#middleware
+     */
+    const middlewares = getDefaultMiddleware().prepend(
+      listenerMiddleware.middleware,
+    );
+
+    // Uncomment the following line if you need to enable logging
+    // during test development.
+    // middlewares.push(logger);
+
+    return middlewares;
+  },
+});

--- a/packages/connect-wallet/src/test/fixtures/connector.ts
+++ b/packages/connect-wallet/src/test/fixtures/connector.ts
@@ -1,0 +1,7 @@
+import {SerializedConnector} from '../../types/connector';
+
+export const DEFAULT_SERIALIZED_CONNECTOR: SerializedConnector = {
+  id: 'MetaMask',
+  name: 'MetaMask',
+  qrCodeSupported: false,
+};

--- a/packages/connect-wallet/src/test/fixtures/signature.ts
+++ b/packages/connect-wallet/src/test/fixtures/signature.ts
@@ -1,0 +1,31 @@
+import {SiweMessage} from 'siwe';
+
+import {SignatureResponse} from '../../types/wallet';
+
+export const MOCK_MESSAGE_DATA = {
+  address: '0xc223594946c60217Ed53096eEC6C179964e536EB',
+  chainId: 1,
+  domain: 'localhost',
+  nonce: 'NAghkPB8sUBqz6s6W',
+  uri: 'http://localhost:5173',
+  version: '1',
+  issuedAt: '2023-01-30T16:24:40.222Z',
+};
+
+export const MOCK_MESSAGE = new SiweMessage(MOCK_MESSAGE_DATA);
+
+export const VALID_SIGNATURE_RESPONSE: SignatureResponse = {
+  address: MOCK_MESSAGE.address,
+  message: JSON.stringify(MOCK_MESSAGE),
+  nonce: MOCK_MESSAGE_DATA.nonce,
+  signature:
+    '0x9ad835c2b18011cfb08798e856ab39b5d4595273c950fbc4f3b7703bbe7f7d026b556c0bff38829e686d9c495274aa2bde80bc06cfa97521b58f9ff9437d95b91b',
+};
+
+export const INVALID_SIGNATURE_RESPONSE: SignatureResponse = {
+  address: MOCK_MESSAGE.address,
+  message: JSON.stringify(MOCK_MESSAGE),
+  nonce: MOCK_MESSAGE_DATA.nonce,
+  signature:
+    '0x0aa04781e381e84b1494d00245b5232ed9106377f541256bb504b75a04a9d2be2e895e4aab9cae3af41344e43ae7d5885202b66b2fa29d4c4443871cfaa575671c',
+};

--- a/packages/connect-wallet/src/test/fixtures/wallet.ts
+++ b/packages/connect-wallet/src/test/fixtures/wallet.ts
@@ -1,0 +1,13 @@
+import {Wallet} from '../../types/wallet';
+
+export const DEFAULT_WALLET: Wallet = {
+  address: '0xc223594946c60217Ed53096eEC6C179964e536EB',
+  connectorId: 'metaMask',
+  connectorName: 'MetaMask',
+};
+
+export const ALTERNATE_WALLET: Wallet = {
+  address: '0x5ea9681C3Ab9B5739810F8b91aE65EC47de62119',
+  connectorId: 'rainbow',
+  connectorName: 'Rainbow',
+};

--- a/packages/connect-wallet/src/types/generics.ts
+++ b/packages/connect-wallet/src/types/generics.ts
@@ -1,2 +1,12 @@
 export type AtLeastOne<T, U = {[K in keyof T]: Pick<T, K>}> = Partial<T> &
   U[keyof U];
+
+/**
+ * Copied from Redux Toolkit listenerMiddleware types
+ */
+export type GuardedType<T> = T extends (
+  x: any,
+  ...args: unknown[]
+) => x is infer T
+  ? T
+  : never;


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->

## What is the context for these changes?
<!-- Share what you're adding, and if necessary, the path you chose and why. -->

Refactors and simplifies the `onConnect` listener logic. This allows for easier middleware creation for `onConnect` events by removing the possibility to missed actions (if the actions for `onConnect` logic are to ever change) and DRYs up the creation of listeners.

The inspiration behind this was not only to DRY up the code a bit, but also because in #4 I am going to re-use this logic (it could likely be reused in #13 as well) for looking up ENS names when a wallet connects.

Note: I was going to add tests for `useMiddleware.ts` as well, however I noticed that we need to create some form of app context in order to render hooks with the state provider. I'd prefer for that to be done the right way, and I believe that doing so will make this PR larger than it should be.

<!-- ℹ️ Delete the following for small / trivial changes -->

## How can this be tophatted?
<!--
  Give as much information as needed to test the changes introduced in this PR.
-->

Primarily green CI (I've added tests for the functionality). However, I will also run `/snapit` and link a CodeSandbox with the snapshot version for testing.

[Test CodeSandbox](https://codesandbox.io/p/sandbox/shopify-connect-wallet-pr-19-hrseiz)

## 🎩 Checklist
<!--
  If any of the following are not relevant you may strike them out using the ~ character before and after the checklist item's label.
-->

- [x] Tested on mobile
- [x] Tested on multiple browsers
- [x] Includes unit tests (see note in the context for the PR)
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
