### PR TITLE
[tokengate] Show discount on unlocked title

### DIFF
--- a/.changeset/gentle-waves-play.md
+++ b/.changeset/gentle-waves-play.md
@@ -1,0 +1,5 @@
+---
+'@shopify/tokengate': minor
+---
+
+Display discount on unlocked title

--- a/packages/tokengate/src/components/Tokengate/utils.spec.ts
+++ b/packages/tokengate/src/components/Tokengate/utils.spec.ts
@@ -145,7 +145,7 @@ describe('Tokengate - utils', () => {
               isLocked: false,
             }),
           );
-          expect(result.current.title).toBe('Discount unlocked');
+          expect(result.current.title).toBe('$10 discount unlocked');
           expect(result.current.subtitle).toBe(
             'Your token got you access to this discount!',
           );
@@ -183,7 +183,7 @@ describe('Tokengate - utils', () => {
               ],
             }),
           );
-          expect(result.current.title).toBe('Discount unlocked');
+          expect(result.current.title).toBe('$10 discount unlocked');
           expect(result.current.subtitle).toBe(
             'You can use this discount up to 4 times with your tokens.',
           );

--- a/packages/tokengate/src/providers/TokengateProvider/translations/en/Tokengate.json
+++ b/packages/tokengate/src/providers/TokengateProvider/translations/en/Tokengate.json
@@ -16,7 +16,7 @@
       "subtitle": "To unlock this discount, you need:"
     },
     "unlocked": {
-      "title": "Discount unlocked",
+      "title": "{{discount}} discount unlocked",
       "subtitle": "Your token got you access to this discount!",
       "subtitleWithOrderLimit": "You can use this discount up to {{orderLimit}} times with your tokens."
     }


### PR DESCRIPTION
## ℹ️ What is the context for these changes?
As a buyer, I want the specific discount I unlocked to be communicated to me in the tokengate card, after passing a gate

## 🕹️ Demonstration
| Before | After |
| -- | -- |
| <img width="414" alt="21-51-drbo3-ghk8f" src="https://user-images.githubusercontent.com/8977776/220484993-6996478c-a4cd-41d6-8787-fc13dc808ec0.png"> | <img width="414" alt="21-51-drbo3-ghk8f" src="https://user-images.githubusercontent.com/8977776/220485040-657fc135-9976-42e2-ad17-1a80335dd0a4.png"> |

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
Can be 🎩 in https://639b1f308693132693d9b82c-lasslndisp.chromatic.com/?path=/story/tokengate-discount-unlocked--no-order-limit

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] Tested on mobile
- [x] Tested on multiple browsers
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
