### PR TITLE
:bug: Resolves an issue with path imports

### DIFF
--- a/.changeset/rude-fishes-smile.md
+++ b/.changeset/rude-fishes-smile.md
@@ -1,0 +1,5 @@
+---
+'@shopify/connect-wallet': patch
+---
+
+Resolves an issue for webpack bundlers that cannot resolve pathed imports

--- a/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
@@ -1,5 +1,5 @@
 import {createAsyncThunk, createSlice, PayloadAction} from '@reduxjs/toolkit';
-import {verifyMessage} from 'ethers/lib/utils';
+import {utils} from 'ethers';
 import {SiweMessage} from 'siwe';
 
 import {SerializedConnector} from '../../types/connector';
@@ -52,7 +52,7 @@ export const validatePendingWallet = createAsyncThunk(
      * Utilize `verifyMessage` from ethers to recover the signer address
      * from the signature.
      */
-    const recoveredAddress = verifyMessage(
+    const recoveredAddress = utils.verifyMessage(
       siweMessage.prepareMessage(),
       signature,
     );


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->
⚠️ Related: https://github.com/Shopify/blockchain-components/issues/16

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

Resolves issue for webpack bundlers which cannot resolve path imports

When using the package inside of a framework that utilizes Webpack you will receive an error stating that ethers/lib/utils could not be resolved. While this doesn't resolve _all_ of the errors of this type (redux-persist is another one that uses pathed imports), it is a step in the right direction.

| Before | After |
| - | - |
| <img width="948" alt="image" src="https://user-images.githubusercontent.com/4250423/221713829-51f41b29-9fc7-4ba7-aa32-69ac1b762d0d.png"> |  <img width="929" alt="image" src="https://user-images.githubusercontent.com/4250423/221714457-511e20ac-1df8-49be-9803-a1a25cc97844.png"> |


## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [ ] ~Tested on multiple browsers~ N/A
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
