### PR TITLE
:bug: Resolves issue with redux-persist path imports

### DIFF
--- a/.changeset/purple-drinks-double.md
+++ b/.changeset/purple-drinks-double.md
@@ -1,0 +1,5 @@
+---
+'@shopify/connect-wallet': patch
+---
+
+Resolves an issue with redux-persist storage import using path imports

--- a/packages/connect-wallet/src/store/combineReducers.ts
+++ b/packages/connect-wallet/src/store/combineReducers.ts
@@ -1,8 +1,9 @@
 import {combineReducers} from '@reduxjs/toolkit';
 import {persistReducer} from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
 
 import {walletSlice, WalletSliceType} from '../slices/walletSlice';
+
+import storage from './storage';
 
 export interface AppState {
   wallet: WalletSliceType;

--- a/packages/connect-wallet/src/store/storage.ts
+++ b/packages/connect-wallet/src/store/storage.ts
@@ -1,0 +1,78 @@
+/**
+ * This file is mostly a copy of the storage functionality from redux-persist
+ * as the package itself uses directory imports which is not supported for
+ * all bundlers (such as Webpack).
+ */
+import {Storage} from 'redux-persist';
+
+const STORAGE_TYPE = 'localStorage';
+
+const noop = () => {};
+const noopStorage = {
+  getItem: noop,
+  setItem: noop,
+  removeItem: noop,
+};
+
+const createStorage = (): Storage => {
+  const storage: Storage = getStorage();
+
+  return {
+    getItem: (key: string): Promise<string> => {
+      return new Promise((resolve) => {
+        resolve(storage.getItem(key));
+      });
+    },
+    setItem: (key: string, item: string): Promise<void> => {
+      return new Promise((resolve) => {
+        resolve(storage.setItem(key, item));
+      });
+    },
+    removeItem: (key: string): Promise<void> => {
+      return new Promise((resolve) => {
+        resolve(storage.removeItem(key));
+      });
+    },
+  };
+};
+
+const getStorage = (): Storage => {
+  if (hasStorage()) {
+    return self[STORAGE_TYPE];
+  }
+
+  // eslint-disable-next-line no-process-env
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(
+      `redux-persist failed to create sync storage. falling back to noop storage.`,
+    );
+  }
+
+  return noopStorage;
+};
+
+function hasStorage() {
+  if (typeof self !== 'object' || !('localStorage' in self)) {
+    return false;
+  }
+
+  try {
+    const storage = self[STORAGE_TYPE];
+    const testKey = `redux-persist ${STORAGE_TYPE} test`;
+    storage.setItem(testKey, 'test');
+    storage.getItem(testKey);
+    storage.removeItem(testKey);
+  } catch (exception) {
+    // eslint-disable-next-line no-process-env
+    if (process.env.NODE_ENV !== 'production')
+      console.warn(
+        `redux-persist ${STORAGE_TYPE} test failed, persistence will be disabled.`,
+      );
+
+    return false;
+  }
+
+  return true;
+}
+
+export default createStorage();


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->
⚠️ Related: https://github.com/Shopify/blockchain-components/issues/16
🔨 Related PR: https://github.com/Shopify/blockchain-components/pull/33

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

> 💡 This is similar to #33, but addresses issues for a different package.

Resolves issue for webpack bundlers which cannot resolve path imports for redux-persist by internalizing the storage object which is used to construct the local storage type for persisted data.

The storage file is similarly constructed to the redux-persist package, but has been simplified slightly as we only need one storage object type (which is local storage). Additionally, it includes changes to the storage construction to ensure the file aligns with our ESLint config.

| Before | After |
| - | - |
|  <img width="929" alt="image" src="https://user-images.githubusercontent.com/4250423/221716129-5b2f7a2b-5be7-4efa-9337-b0e0c31cae0f.png"> | Coming soon |


## 🕹️ Demonstration

<!--
  Showcase what you've created!

  - Before / after screenshots are appreciated for UI changes.
  - Videos may help better explain the changes being made in larger codebase changes.
  - If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

...

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

...

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] Tested on mobile
- [ ] Tested on multiple browsers
- [ ] Tested for accessibility
- [ ] Includes unit tests
- [ ] Updated relevant documentation for the changes (if necessary)
