### PR TITLE
[analytics] Add `ClientAnalytics` to shared package

### DIFF
--- a/.changeset/unlucky-days-notice.md
+++ b/.changeset/unlucky-days-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/tokengate': minor
+---
+
+Adds new ClientAnalytics component

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -49,3 +49,4 @@ export type {Theme, ThemeProps} from './types/theme';
 export {formatWalletAddress} from './utils/formatters';
 export {deepMerge} from './utils/deepMerge';
 export {addDays} from './utils/date';
+export {ClientAnalytics} from './utils/analytics';

--- a/packages/shared/src/utils/analytics/ClientAnalytics.ts
+++ b/packages/shared/src/utils/analytics/ClientAnalytics.ts
@@ -1,0 +1,46 @@
+import {SubscriberFunction, Subscriber, Subscribers} from './types';
+import {eventNames} from './const';
+
+const subscribers: Subscribers = {};
+
+const subscribe = (
+  eventname: string,
+  callbackFunction: SubscriberFunction,
+): Subscriber => {
+  const subs = subscribers[eventname];
+
+  // subs could be undefined, but the casting of subscribers to Subscribers
+  // does not let the linter understand that it could be undefined
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!subs) {
+    subscribers[eventname] = {};
+  }
+
+  const subscriberId = Date.now().toString();
+  subscribers[eventname][subscriberId] = callbackFunction;
+
+  return {
+    unsubscribe: () => {
+      delete subscribers[eventname][subscriberId];
+    },
+  };
+};
+
+const publishEvent = (eventname: string, payload?: any) => {
+  const subs = subscribers[eventname];
+
+  // subs could be undefined, but the casting of subscribers to Subscribers
+  // does not let the linter understand that it could be undefined
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (subs) {
+    Object.keys(subs).forEach((key) => {
+      subs[key](payload);
+    });
+  }
+};
+
+export const ClientAnalytics = {
+  subscribe,
+  publishEvent,
+  eventNames,
+};

--- a/packages/shared/src/utils/analytics/const.ts
+++ b/packages/shared/src/utils/analytics/const.ts
@@ -1,0 +1,3 @@
+export const eventNames = {
+  TOKENGATE_COMPONENT_RENDERED: 'TOKENGATE_COMPONENT_RENDERED',
+};

--- a/packages/shared/src/utils/analytics/index.ts
+++ b/packages/shared/src/utils/analytics/index.ts
@@ -1,0 +1,1 @@
+export {ClientAnalytics} from './ClientAnalytics';

--- a/packages/shared/src/utils/analytics/types.ts
+++ b/packages/shared/src/utils/analytics/types.ts
@@ -1,0 +1,5 @@
+export interface Subscriber {
+  unsubscribe: () => void;
+}
+export type SubscriberFunction = (payload: any) => void;
+export type Subscribers = Record<string, Record<string, SubscriberFunction>>;

--- a/packages/tokengate/src/components/Tokengate/Tokengate.tsx
+++ b/packages/tokengate/src/components/Tokengate/Tokengate.tsx
@@ -1,4 +1,5 @@
-import {ReactNode, Fragment, useMemo} from 'react';
+import {ReactNode, Fragment, useMemo, useEffect} from 'react';
+import {ClientAnalytics} from 'shared';
 
 import {AvailableSoonButton} from '../AvailableSoonButton';
 import {Card} from '../Card';
@@ -22,6 +23,12 @@ export const Tokengate = (props: TokengateProps) => {
     redemptionLimit,
   } = props;
   const {title, subtitle, sections} = useTokengateCardState(props);
+
+  useEffect(() => {
+    ClientAnalytics.publishEvent(
+      ClientAnalytics.eventNames.TOKENGATE_COMPONENT_RENDERED,
+    );
+  }, []);
 
   const sectionMapping: {[key in TokengateCardSection]: ReactNode} = useMemo(
     () => ({

--- a/packages/tokengate/src/index.ts
+++ b/packages/tokengate/src/index.ts
@@ -21,3 +21,8 @@ export {Dawn, Default};
  */
 export type {Theme};
 export * from './types';
+
+/**
+ * ClientAnalytics
+ */
+export {ClientAnalytics} from 'shared';


### PR DESCRIPTION
## ℹ️ What is the context for these changes?
Creates a new shared util `ClientAnalytics` based on Hydrogen's [one](https://github.com/Shopify/hydrogen-v1/blob/main/packages/hydrogen/src/foundation/Analytics/ClientAnalytics.tsx#L15).

This new `ClientAnalytics` util function will allow the developers using the components to subscribe to the tracked events and forward the events to their preferred analytics service. 

You can see in this follow-up example how we can use it, having the Playground as an example: https://github.com/Shopify/blockchain-components/pull/40

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [ ] ~Tested on multiple browsers~ N/A
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A, I added tests, but I noticed the tests under the shared folder are not running. We'll have to address this in a separate PR
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A, will update in a follow up PR
