### PR TITLE
Gate context: Moves window inspection on import

### DIFF
--- a/.changeset/sharp-years-relate.md
+++ b/.changeset/sharp-years-relate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/gate-context-client': patch
+---
+
+Removes window inspection upon import

--- a/packages/gate-context-client/src/cartAjaxApi/cartAjaxApi.ts
+++ b/packages/gate-context-client/src/cartAjaxApi/cartAjaxApi.ts
@@ -15,8 +15,6 @@ import {CartAjaxApiError, CartAjaxApiNotSupportedError} from './errors';
 import {getShopifyRootRoute, isShopifyStore} from './shopify';
 import {CartAjaxAPICartAttributes, CartAjaxApiResponse} from './types';
 
-const AJAX_API_UPDATE_URL = getUpdateUrl();
-
 async function read(): Promise<unknown> {
   if (!isCartAjaxApiSupported()) {
     return Promise.reject(new CartAjaxApiNotSupportedError());
@@ -58,7 +56,7 @@ async function write<TGateContext, TRawResponse>(
     return Promise.reject(new CartAjaxApiNotSupportedError());
   }
 
-  const response = await fetch(AJAX_API_UPDATE_URL, {
+  const response = await fetch(getUpdateUrl(), {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({


### PR DESCRIPTION
Inspecting window on import causes issues with SSR.

When testing using the packages with Next.JS, we saw an error that `window` was not available. `window` is not available on the server-side, but the function referencing it was being invoked at import.

To resolve, we could either check whether window is defined before using it, or move the function call so that it doesn't happen on import. I am doing the latter because there are other functions that check whether window is defined.

- [ ] Tested on mobile
- [ ] Tested on multiple browsers
- [ ] Tested for accessibility
- [x] Includes unit tests - there are existing unit tests
- [ ] Updated relevant documentation for the changes (if necessary)
