### PR TITLE
:bug: Addresses issue with styled-components and webpack

### DIFF
--- a/.changeset/loud-cups-promise.md
+++ b/.changeset/loud-cups-promise.md
@@ -1,0 +1,6 @@
+---
+'@shopify/connect-wallet': patch
+'@shopify/tokengate': patch
+---
+
+Addresses an issue with styled components and CJS support. Since the packages support ESM, some frameworks (Next.js) will try to transpile the packages and use a CommonJS version of styled-components we needed to re-export styled-components with a .default key for CJS support.

--- a/packages/connect-wallet/package.json
+++ b/packages/connect-wallet/package.json
@@ -47,7 +47,6 @@
     "redux-logger": "^3.0.6",
     "redux-persist": "^6.0.0",
     "siwe": "^1.1.6",
-    "styled-components": "^5.3.6",
     "ua-parser-js": "^1.0.32"
   },
   "peerDependencies": {
@@ -61,7 +60,6 @@
     "@testing-library/react": "^13.4.0",
     "@types/qrcode": "^1.5.0",
     "@types/redux-logger": "^3.0.9",
-    "@types/styled-components": "^5.1.26",
     "@types/ua-parser-js": "^0.7.36",
     "@wagmi/core": "0.8.10",
     "happy-dom": "^8.7.1",

--- a/packages/connect-wallet/src/components/ConnectButton/style.ts
+++ b/packages/connect-wallet/src/components/ConnectButton/style.ts
@@ -1,5 +1,4 @@
-import {breakpoints, ButtonWrapper} from 'shared';
-import styled from 'styled-components';
+import {breakpoints, ButtonWrapper, styled} from 'shared';
 
 export const AddressChip = styled.button`
   appearance: none;

--- a/packages/connect-wallet/src/components/ConnectorButton/style.ts
+++ b/packages/connect-wallet/src/components/ConnectorButton/style.ts
@@ -1,5 +1,4 @@
-import styled from 'styled-components';
-import {ButtonWrapper} from 'shared';
+import {ButtonWrapper, styled} from 'shared';
 
 export const Button = styled(ButtonWrapper)`
   display: flex;

--- a/packages/connect-wallet/src/components/ConnectorIcon/style.ts
+++ b/packages/connect-wallet/src/components/ConnectorIcon/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 import {Size} from '../../types/sizes';
 

--- a/packages/connect-wallet/src/components/GetAConnectorButton/style.ts
+++ b/packages/connect-wallet/src/components/GetAConnectorButton/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 export const Wrapper = styled.div`
   display: flex;

--- a/packages/connect-wallet/src/components/Modal/style.ts
+++ b/packages/connect-wallet/src/components/Modal/style.ts
@@ -1,5 +1,5 @@
-import styled, {CSSProperties} from 'styled-components';
-import {breakpoints} from 'shared';
+import {CSSProperties} from 'react';
+import {breakpoints, styled} from 'shared';
 
 export const Background = styled.div`
   position: absolute;

--- a/packages/connect-wallet/src/components/QRCode/style.ts
+++ b/packages/connect-wallet/src/components/QRCode/style.ts
@@ -1,4 +1,5 @@
-import styled, {CSSProperties} from 'styled-components';
+import {CSSProperties} from 'react';
+import {styled} from 'shared';
 
 export const Circle = styled.circle`
   fill: ${({theme}) => theme.typography.colorPrimary};

--- a/packages/connect-wallet/tsup.config.ts
+++ b/packages/connect-wallet/tsup.config.ts
@@ -3,7 +3,7 @@ import {defineConfig, Options} from 'tsup';
 
 const BASE_CONFIG: Options = {
   entry: ['./src/index.ts'],
-  external: ['ethers', 'react', 'styled-components', 'wagmi'],
+  external: ['ethers', 'react', 'wagmi'],
   format: ['esm'],
   platform: 'browser',
   target: 'esnext',

--- a/packages/shared/src/components/Button/style.ts
+++ b/packages/shared/src/components/Button/style.ts
@@ -1,5 +1,4 @@
-import styled, {css} from 'styled-components';
-
+import styled, {css} from '../../styles/styled';
 import {ThemedCSS} from '../../types/theme';
 
 import {Size} from './types';

--- a/packages/shared/src/components/IconButton/style.ts
+++ b/packages/shared/src/components/IconButton/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from '../../styles/styled';
 
 export const StyledButton = styled.button`
   display: flex;

--- a/packages/shared/src/components/SkeletonDisplayText/SkeletonDisplayText.tsx
+++ b/packages/shared/src/components/SkeletonDisplayText/SkeletonDisplayText.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from '../../styles/styled';
 
 export const SkeletonDisplayText = styled.div`
   background-color: #e4e5e7;

--- a/packages/shared/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
+++ b/packages/shared/src/components/SkeletonThumbnail/SkeletonThumbnail.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from '../../styles/styled';
 
 export const SkeletonThumbnail = styled.div<{size?: number}>`
   background-color: #e4e5e7;

--- a/packages/shared/src/components/Spinner/style.ts
+++ b/packages/shared/src/components/Spinner/style.ts
@@ -1,4 +1,4 @@
-import styled, {keyframes} from 'styled-components';
+import styled, {keyframes} from '../../styles/styled';
 
 const spinAnimation = keyframes`
     to {

--- a/packages/shared/src/components/Text/style.ts
+++ b/packages/shared/src/components/Text/style.ts
@@ -1,5 +1,4 @@
-import styled, {css} from 'styled-components';
-
+import styled, {css} from '../../styles/styled';
 import {ThemedCSS} from '../../types/theme';
 
 import {Color, Variant} from './types';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -31,6 +31,7 @@ export {RootProvider} from './providers/RootProvider';
  */
 export {breakpoints, device} from './styles/breakpoints';
 export {NonEmptyElement} from './styles/sharedStyles';
+export {default as styled, css, keyframes} from './styles/styled';
 
 /**
  * Themes

--- a/packages/shared/src/styles/sharedStyles.ts
+++ b/packages/shared/src/styles/sharedStyles.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {createGlobalStyle, css} from 'styled-components';
+import {createGlobalStyle, css} from './styled';
 
 /**
  * We restrict the use of `createGlobalStyle` because it affects all elements

--- a/packages/shared/src/styles/styled.ts
+++ b/packages/shared/src/styles/styled.ts
@@ -1,0 +1,10 @@
+/* eslint-disable no-restricted-imports */
+import styled, {StyledInterface} from 'styled-components';
+
+export * from 'styled-components';
+
+export default (typeof styled.div === 'function'
+  ? styled
+  : // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    styled.default) as StyledInterface;

--- a/packages/shared/src/types/theme.ts
+++ b/packages/shared/src/types/theme.ts
@@ -1,9 +1,10 @@
 import {PropsWithChildren} from 'react';
+
 import {
   CSSProperties,
   FlattenInterpolation,
   ThemeProps as StyledThemeProps,
-} from 'styled-components';
+} from '../styles/styled';
 
 type RequiredCSSProperty = Required<CSSProperties>;
 

--- a/packages/shared/styled.d.ts
+++ b/packages/shared/styled.d.ts
@@ -1,5 +1,3 @@
-import styled from 'styled-components';
-
 import {Theme} from './src/types/theme';
 
 declare module 'styled-components' {

--- a/packages/tokengate/package.json
+++ b/packages/tokengate/package.json
@@ -43,12 +43,10 @@
     "i18next": "^22.4.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-i18next": "^12.1.4",
-    "styled-components": "^5.3.6"
+    "react-i18next": "^12.1.4"
   },
   "devDependencies": {
     "@storybook/react": "^6.5.13",
-    "@types/styled-components": "^5.1.26",
     "@testing-library/react": "^13.4.0",
     "shared": "*",
     "tsconfig": "*",

--- a/packages/tokengate/src/components/Card/style.ts
+++ b/packages/tokengate/src/components/Card/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 export const StyledCard = styled.div`
   background-color: ${({theme}) => theme.tokengate.background};

--- a/packages/tokengate/src/components/Error/style.ts
+++ b/packages/tokengate/src/components/Error/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 export const Wrapper = styled.div`
   p {

--- a/packages/tokengate/src/components/SoldOutButton/style.ts
+++ b/packages/tokengate/src/components/SoldOutButton/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 export const Wrapper = styled.div`
   width: 100%;

--- a/packages/tokengate/src/components/TokenBase/style.ts
+++ b/packages/tokengate/src/components/TokenBase/style.ts
@@ -1,5 +1,4 @@
-import {SkeletonThumbnail} from 'shared';
-import styled from 'styled-components';
+import {SkeletonThumbnail, styled} from 'shared';
 
 export const TokenBaseStyle = styled.div`
   display: flex;

--- a/packages/tokengate/src/components/TokenList/style.ts
+++ b/packages/tokengate/src/components/TokenList/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 export const TokenListImageStyle = styled.img`
   width: 100%;

--- a/packages/tokengate/src/components/Tokengate/stories/playground/style.ts
+++ b/packages/tokengate/src/components/Tokengate/stories/playground/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 export const Wrapper = styled.div`
   display: flex;

--- a/packages/tokengate/src/components/TokengateRequirements/style.ts
+++ b/packages/tokengate/src/components/TokengateRequirements/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import {styled} from 'shared';
 
 export const TokengateRequirementsSeparatorStyle = styled.div<{$gap: string}>`
   display: flex;

--- a/packages/tokengate/tsup.config.ts
+++ b/packages/tokengate/tsup.config.ts
@@ -3,7 +3,7 @@ import {defineConfig, Options} from 'tsup';
 
 const BASE_CONFIG: Options = {
   entry: ['./src/index.ts'],
-  external: ['react', 'styled-components'],
+  external: ['react'],
   format: ['esm', 'cjs'],
   platform: 'browser',
   target: 'esnext',


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

Addresses an issue with styled-components and webpack. The problem occurs when styled-components is used inside of an ESM only package that is used within a webpack-based bundler (e.g. CRA + Next.js). 

ESM allows for importing in the syntax we're all familiar with. However, the ESM support that Next.js ships with still utilizes `require` instead of `import`. This means that the compiled styled-components code will look like `styled.default.span` rather than `styled.span`, which is why you see the error demonstrated in the before section below.

There are other approaches to resolving this which I considered, but decided against since they require more lift, such as:
- Upgrading to an alpha package of Styled Components (Version 6 is supposed to ship with ESM support, however when testing V6 I ran into type mismatching and other weird behavior.
- Using a different styling library (TailwindCSS, Vanilla Extract, CSS Modules)

To explain the solution here, what I've effectively done is re-exported styled-components with a "hacky" way of providing backwards-compatible CJS/ESM support. [You can read more about this approach here](https://github.com/styled-components/styled-components/issues/3437#issuecomment-1103085056). You can see [this implementation](https://github.com/Shopify/blockchain-components/blob/93a4685cd39eb35143dca5cb5e8e6423205aff8f/packages/shared/src/styles/styled.ts) here.

## 🕹️ Demonstration

<!--
  Showcase what you've created!

  - Before / after screenshots are appreciated for UI changes.
  - Videos may help better explain the changes being made in larger codebase changes.
  - If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

| State | Image |
| - | - |
| Before | ![SCR-20230302-m1h](https://user-images.githubusercontent.com/4250423/222574722-d20ee891-292f-4187-b36e-1f26e26bac26.png) |
| After | ![SCR-20230302-mz6](https://user-images.githubusercontent.com/4250423/222574855-e530ebd2-4205-4634-9fa1-cfcf9e006b5b.png) |

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

To test this, you will need a Next.js app to test with

1. Pull this PR
2. Install dependencies, build the packages, and then link the package `dev up && yarn build && cd packages/connect-wallet && yarn link`
3. Navigate to your Next.js test application and run the following: `yarn link "@shopify/connect-wallet"`
4. Run your application and you should see a Wagmi error (temporary)

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] Tested on mobile
- [x] Tested on multiple browsers
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
