### PR TITLE
Supports allow list using condition desc prop and custom titles

### DIFF
--- a/.changeset/seven-birds-change.md
+++ b/.changeset/seven-birds-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/tokengate': minor
+---
+
+Adds description prop to Condition type and makes collectionAddress optional.

--- a/packages/tokengate/src/components/TokenBase/TokenBase.tsx
+++ b/packages/tokengate/src/components/TokenBase/TokenBase.tsx
@@ -1,3 +1,4 @@
+import {ReactNode} from 'react';
 import {Text} from 'shared';
 
 import {
@@ -9,7 +10,7 @@ import {
 
 interface TokenBaseProps {
   title?: string;
-  subtitle?: string;
+  subtitle?: ReactNode;
   icon: React.ReactNode;
   round: boolean;
   badge?: React.ReactNode;

--- a/packages/tokengate/src/components/TokenList/types.ts
+++ b/packages/tokengate/src/components/TokenList/types.ts
@@ -1,7 +1,9 @@
+import {ReactNode} from 'react';
+
 export interface TokenListProps {
   tokens?: {
     title: string;
-    subtitle: string;
+    subtitle: ReactNode;
     imageUrl?: string;
     badge?: React.ReactNode;
     round?: boolean;

--- a/packages/tokengate/src/components/Tokengate/stories/scenarios/AllowList.stories.tsx
+++ b/packages/tokengate/src/components/Tokengate/stories/scenarios/AllowList.stories.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable @shopify/jsx-no-hardcoded-content */
+
+import {Meta, StoryObj} from '@storybook/react';
+import {Button} from 'shared';
+
+import {Template} from '../template';
+import {ReactionFixture, TokengatePropsFixture} from '../../../../fixtures';
+import {Tokengate} from '../../Tokengate';
+
+const TokengateStory: Meta<typeof Tokengate> = {
+  title: 'Tokengate/AllowList',
+  component: Tokengate,
+};
+
+export default TokengateStory;
+
+const defaultArgs = TokengatePropsFixture({
+  isConnected: false,
+  isLocked: true,
+  reaction: ReactionFixture(),
+  requirements: {
+    logic: 'ANY' as const,
+    conditions: [
+      {
+        name: 'Best wallet holders',
+        description: 'Optional description',
+      },
+    ],
+  },
+  redemptionLimit: {total: 4, perToken: 4},
+  discountCustomTitles: getCustomTitles(),
+  exclusiveCustomTitles: getCustomTitles(),
+});
+
+const AllowListComponent = (args: typeof defaultArgs) => {
+  const {
+    isConnected,
+    isLocked,
+    requirements: originalRequirements,
+    discountCustomTitles: originalDiscountCustomTitles,
+    exclusiveCustomTitles: originalExclusiveCustomTitles,
+  } = args;
+  const isNotOnAllowList = isConnected && isLocked;
+
+  const connectButton = <Button label="Connect wallet" fullWidth primary />;
+  const connectedButton = <Button label="0xab...aec9b" fullWidth />;
+
+  // Customize display of the case where the user is not on the allow list
+  const requirements = isNotOnAllowList
+    ? {
+        ...originalRequirements!,
+        conditions: [
+          {
+            name: "You're not on the list!",
+            description: "You're not on the list!",
+          },
+        ],
+      }
+    : originalRequirements!;
+  const overrideTitles = isNotOnAllowList
+    ? {lockedSubtitle: "You're not on the list!"}
+    : {};
+  const discountCustomTitles = {
+    ...originalDiscountCustomTitles!,
+    ...overrideTitles,
+  };
+  const exclusiveCustomTitles = {
+    ...originalExclusiveCustomTitles!,
+    ...overrideTitles,
+  };
+
+  return (
+    <Template
+      {...args}
+      requirements={requirements}
+      connectButton={isConnected ? connectedButton : connectButton}
+      exclusiveCustomTitles={exclusiveCustomTitles}
+      discountCustomTitles={discountCustomTitles}
+    />
+  );
+};
+
+type Story = StoryObj<typeof AllowListComponent>;
+
+export const AllowList: Story = {
+  args: defaultArgs,
+  render: (args) => <AllowListComponent {...args} />,
+  argTypes: {
+    connectButton: {
+      table: {
+        disable: true,
+      },
+    },
+    connectedButton: {
+      table: {
+        disable: true,
+      },
+    },
+    redemptionLimit: {
+      table: {
+        disable: true,
+      },
+    },
+    theme: {
+      table: {
+        disable: true,
+      },
+    },
+    unlockingTokens: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+};
+
+function getCustomTitles() {
+  return {
+    lockedTitle: `Exclusive product`,
+    lockedSubtitle: `On the allow list? You're in!`,
+    unlockedTitle: `You're in!`,
+    unlockedSubtitleWithRedemptionLimit: (
+      <>
+        You can <b>buy up to 4</b> with your tokens
+      </>
+    ),
+  };
+}

--- a/packages/tokengate/src/components/Tokengate/stories/template.tsx
+++ b/packages/tokengate/src/components/Tokengate/stories/template.tsx
@@ -3,10 +3,12 @@ import {Button} from 'shared';
 import {Tokengate} from '../Tokengate';
 import type {TokengateProps} from '../../../types';
 
-export const Template = (args: TokengateProps) => (
-  <Tokengate
-    {...args}
-    connectButton={<Button label="Connect wallet" fullWidth primary />}
-    connectedButton={<Button label="0xab...aec9b" fullWidth />}
-  />
-);
+export const Template = (argOverrides: Partial<TokengateProps>) => {
+  const args: TokengateProps = {
+    isConnected: false,
+    connectButton: <Button label="Connect wallet" fullWidth primary />,
+    connectedButton: <Button label="0xab...aec9b" fullWidth />,
+    ...argOverrides,
+  };
+  return <Tokengate {...args} />;
+};

--- a/packages/tokengate/src/components/Tokengate/utils.ts
+++ b/packages/tokengate/src/components/Tokengate/utils.ts
@@ -184,7 +184,7 @@ export const calculatedIsLocked = (props: TokengateProps) => {
         unlockingTokens.find(
           (unlockingToken) =>
             unlockingToken.collectionAddress.toLowerCase() ===
-            condition.collectionAddress.toLowerCase(),
+            condition.collectionAddress?.toLowerCase(),
         ),
       ),
   );

--- a/packages/tokengate/src/components/TokengateRequirements/utils.test.tsx
+++ b/packages/tokengate/src/components/TokengateRequirements/utils.test.tsx
@@ -1,0 +1,17 @@
+import {getConditionTitle} from './utils';
+
+describe('getConditionTitle', () => {
+  it('returns the name when available', () => {
+    expect(getConditionTitle({name: 'foo'})).toBe('foo');
+  });
+
+  it('returns the formatted collection address when available', () => {
+    expect(getConditionTitle({collectionAddress: '0x1234567890'})).toBe(
+      'contract 0x12...7890',
+    );
+  });
+
+  it('returns blank string when no name or collection address', () => {
+    expect(getConditionTitle({})).toBe('');
+  });
+});

--- a/packages/tokengate/src/components/TokengateRequirements/utils.tsx
+++ b/packages/tokengate/src/components/TokengateRequirements/utils.tsx
@@ -30,15 +30,21 @@ export const mapRequirementsToTokenListProps = ({
     }
 
     return {
-      title:
-        condition.name ??
-        `contract ${formatWalletAddress(condition.collectionAddress)}`,
-      subtitle: t('conditionDescription.any'),
+      title: getConditionTitle(condition),
+      subtitle: condition.description ?? t('conditionDescription.any'),
       imageUrl: condition.imageUrl,
       badge,
       round: true,
     };
   });
+
+export const getConditionTitle = ({name, collectionAddress}: Condition) => {
+  if (name) return name;
+
+  if (!collectionAddress) return '';
+
+  return `contract ${formatWalletAddress(collectionAddress)}`;
+};
 
 export const findUnlockingTokenForCondition = ({
   condition,

--- a/packages/tokengate/src/types.ts
+++ b/packages/tokengate/src/types.ts
@@ -4,7 +4,8 @@ import {ThemeProps} from 'shared';
 export interface Condition {
   name?: string;
   imageUrl?: string;
-  collectionAddress: string;
+  collectionAddress?: string;
+  description?: ReactNode;
 }
 
 export interface Requirements {
@@ -21,11 +22,11 @@ export interface UnlockingToken {
 }
 
 export interface CustomTitles {
-  lockedTitle?: string;
-  lockedSubtitle?: string;
-  unlockedTitle?: string;
-  unlockedSubtitle?: string;
-  unlockedSubtitleWithRedemptionLimit?: string;
+  lockedTitle?: ReactNode;
+  lockedSubtitle?: ReactNode;
+  unlockedTitle?: ReactNode;
+  unlockedSubtitle?: ReactNode;
+  unlockedSubtitleWithRedemptionLimit?: ReactNode;
 }
 
 export interface RedemptionLimit {


### PR DESCRIPTION
## ℹ️ What is the context for these changes?

Adds support for customizing what's displayed in segment descriptions in order to support use-cases such as gating using wallet address allow lists.

There are two main changes:

1. `Condition#collectionAddress` is allowed to be optional
2. `Condition#description` has been added and is a React node.
3. All the props of `CustomTitles` may be React nodes

Note that I experimented with `Condition#name` being a React node, but it's expected to be a string in a few different places such as a fragment key. Since `name` doesn't have to be a node to meet the requirements, I left as-is.

## 🕹️ Demonstration

### Locked

<img width="441" alt="image" src="https://user-images.githubusercontent.com/187039/222827808-a24f67c9-2921-4d69-aa11-bf16f8c68c37.png">

### Unlocked

![image](https://user-images.githubusercontent.com/187039/223502010-d8b45032-9926-440c-a49b-f67b3ac6d85c.png)



## 🎩 How can this be tophatted?

* View (https://gracefulvastphp.jamiely.repl.co/)
* Code (https://replit.com/join/eebzcxrjbv-jamiely)

## ✅ Checklist

- [x] Tested on mobile
- [x] Tested on multiple browsers
- [ ] Tested for accessibility
- [x] Includes unit tests
- [ ] Updated relevant documentation for the changes (if necessary) - I'll update public docs if this is merged.
