### PR TITLE
Adding test infra for providers and testing useConnectorData

### DIFF
--- a/packages/connect-wallet/src/hooks/useConnectorData.test.ts
+++ b/packages/connect-wallet/src/hooks/useConnectorData.test.ts
@@ -1,0 +1,41 @@
+import {
+  CHAINS,
+  CUSTOM_CONNECTOR,
+  DEFAULT_CONNECTOR_COLLECTION,
+} from '../test/fixtures/connector';
+import {createWagmiFixture} from '../test/fixtures/wagmi';
+
+import {renderHookWithContext} from '../test/utils';
+
+import {useConnectorData} from './useConnectorData';
+
+describe('useConnectorData', () => {
+  it('returns custom connector id', () => {
+    const {client} = createWagmiFixture({customConnectors: [CUSTOM_CONNECTOR]});
+
+    const {result} = renderHookWithContext(
+      () => useConnectorData({id: CUSTOM_CONNECTOR.id}),
+      {
+        chains: CHAINS,
+        client,
+        connectors: [CUSTOM_CONNECTOR],
+      },
+    );
+
+    expect(result.current).toEqual(expect.objectContaining(CUSTOM_CONNECTOR));
+  });
+
+  it('returns correct data based on id for default connectors', () => {
+    const {client, connectors} = createWagmiFixture({});
+
+    DEFAULT_CONNECTOR_COLLECTION.forEach((id) => {
+      const {result} = renderHookWithContext(() => useConnectorData({id}), {
+        chains: CHAINS,
+        client,
+        connectors,
+      });
+
+      expect(result.current).toEqual(expect.objectContaining({id}));
+    });
+  });
+});

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/index.ts
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/index.ts
@@ -2,3 +2,4 @@ export {ConnectWalletContext} from './context';
 export {ConnectWalletProvider} from './provider';
 
 export type {ConnectWalletProviderValue} from './context';
+export type {ProviderProps} from './types';

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/provider.tsx
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/provider.tsx
@@ -1,5 +1,5 @@
 import {MotionConfig} from 'framer-motion';
-import {FC, PropsWithChildren, useMemo} from 'react';
+import {FC, useMemo} from 'react';
 import {Provider} from 'react-redux';
 import {RootProvider} from 'shared';
 
@@ -11,7 +11,7 @@ import store from '../../store/configureStore';
 import {ConnectWalletContext, ConnectWalletProviderValue} from './context';
 import {ProviderProps} from './types';
 
-export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
+export const ConnectWalletProvider: FC<ProviderProps> = ({
   chains,
   connectors,
   children,
@@ -19,7 +19,7 @@ export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
   orderAttributionMode = 'required',
   statementGenerator,
   theme,
-}: PropsWithChildren<ProviderProps>) => {
+}: ProviderProps) => {
   const contextValue: ConnectWalletProviderValue = useMemo(() => {
     let contextualConnectors = connectors;
 

--- a/packages/connect-wallet/src/test/PackageContext.tsx
+++ b/packages/connect-wallet/src/test/PackageContext.tsx
@@ -1,0 +1,22 @@
+import {WagmiConfig} from 'wagmi';
+
+import {ConnectWalletProvider} from '../providers/ConnectWalletProvider';
+import type {ProviderProps} from '../providers/ConnectWalletProvider';
+
+import {createWagmiFixture} from './fixtures/wagmi';
+
+export type PackageContextProps = ProviderProps & {
+  client: ReturnType<typeof createWagmiFixture>['client'];
+};
+
+export const PackageContext = ({
+  children,
+  client,
+  ...props
+}: PackageContextProps) => {
+  return (
+    <WagmiConfig client={client}>
+      <ConnectWalletProvider {...props}>{children}</ConnectWalletProvider>
+    </WagmiConfig>
+  );
+};

--- a/packages/connect-wallet/src/test/fixtures/connector.ts
+++ b/packages/connect-wallet/src/test/fixtures/connector.ts
@@ -6,7 +6,7 @@ import {publicProvider} from 'wagmi/providers/public';
 import {SerializedConnector} from '../../types/connector';
 
 export const DEFAULT_SERIALIZED_CONNECTOR: SerializedConnector = {
-  id: 'MetaMask',
+  id: 'metaMask',
   name: 'MetaMask',
   qrCodeSupported: false,
 };
@@ -24,3 +24,10 @@ export const CUSTOM_CONNECTOR = {
   qrCodeSupported: false,
   connector: INJECTED_CONNECTOR,
 };
+
+export const DEFAULT_CONNECTOR_COLLECTION = [
+  'metaMask',
+  'rainbow',
+  'ledger',
+  'walletConnect',
+];

--- a/packages/connect-wallet/src/test/fixtures/wagmi.ts
+++ b/packages/connect-wallet/src/test/fixtures/wagmi.ts
@@ -1,0 +1,38 @@
+import {
+  buildConnectors,
+  BuildConnectorsProps,
+} from 'src/connectors/buildConnectors';
+import {Chain, configureChains, createClient} from 'wagmi';
+import {mainnet} from 'wagmi/chains';
+import {publicProvider} from 'wagmi/providers/public';
+
+type WagmiFixtureProps = Omit<BuildConnectorsProps, 'chains'> & {
+  chains?: Chain[];
+};
+
+export const createWagmiFixture = ({
+  appName,
+  chains = [mainnet],
+  customConnectors,
+  excludedConnectors = ['coinbaseWallet'],
+}: WagmiFixtureProps) => {
+  const {provider, webSocketProvider} = configureChains(chains, [
+    publicProvider(),
+  ]);
+
+  const {connectors, wagmiConnectors} = buildConnectors({
+    appName,
+    chains,
+    customConnectors,
+    excludedConnectors,
+  });
+
+  const client = createClient({
+    autoConnect: true,
+    connectors: wagmiConnectors,
+    provider,
+    webSocketProvider,
+  });
+
+  return {chains, client, connectors};
+};

--- a/packages/connect-wallet/src/test/utils.tsx
+++ b/packages/connect-wallet/src/test/utils.tsx
@@ -1,0 +1,34 @@
+import {
+  render,
+  renderHook,
+  RenderHookOptions,
+  RenderHookResult,
+  RenderOptions,
+} from '@testing-library/react';
+import {ReactElement} from 'react';
+
+import {PackageContext, PackageContextProps} from './PackageContext';
+
+const renderWithContext = (
+  ui: ReactElement,
+  contextProps: PackageContextProps,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) =>
+  render(ui, {
+    wrapper: (props) => <PackageContext {...props} {...contextProps} />,
+    ...options,
+  });
+
+function renderHookWithContext<TResult, TProps>(
+  render: (props: TProps) => TResult,
+  contextProps: PackageContextProps,
+  options?: RenderHookOptions<TProps>,
+): RenderHookResult<TResult, TProps> {
+  return renderHook(render, {
+    wrapper: (props) => <PackageContext {...props} {...contextProps} />,
+    ...options,
+  });
+}
+
+export * from '@testing-library/react';
+export {renderWithContext as render, renderHookWithContext};


### PR DESCRIPTION
## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

To be able to test the changes made to the `ConnectWalletProvider` in the [Customizable wallet list](https://github.com/Shopify/blockchain-components/pull/55) epic, we need to:
1. Add test infrastructure to be able to test with contexts and test hooks with context. This is also outlined in [this issue](https://github.com/Shopify/nft-gating/issues/1315) and this PR will close it as well. 
2. Test a consumer of `ConnectWalletProvider`, which in this case is the `useConnectorData` hook

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] ~~Tested on mobile~~
- [x] ~~Tested on multiple browsers~~
- [x] ~~Tested for accessibility~~
- [x] Includes unit tests
- [x] ~~Updated relevant documentation for the changes (if necessary)~~
