### PR TITLE
[analytics] Add cookies utils

### DIFF
--- a/.changeset/seven-rocks-agree.md
+++ b/.changeset/seven-rocks-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/blockchain-components': minor
+---
+
+Add cookies utils for analytics

--- a/packages/blockchain-components/package.json
+++ b/packages/blockchain-components/package.json
@@ -50,5 +50,8 @@
     "tsup": "^6.5.0",
     "vitest": "^0.28.5",
     "vitest-fetch-mock": "^0.2.1"
+  },
+  "dependencies": {
+    "worktop": "^0.7.3"
   }
 }

--- a/packages/blockchain-components/src/utils/cookies/const.ts
+++ b/packages/blockchain-components/src/utils/cookies/const.ts
@@ -1,0 +1,2 @@
+export const SHOPIFY_Y = '_shopify_y';
+export const SHOPIFY_S = '_shopify_s';

--- a/packages/blockchain-components/src/utils/cookies/index.ts
+++ b/packages/blockchain-components/src/utils/cookies/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Const
+ */
+export {SHOPIFY_S, SHOPIFY_Y} from './const';
+
+/**
+ * Utils
+ */
+export {getShopifyCookies} from './utils';

--- a/packages/blockchain-components/src/utils/cookies/types.ts
+++ b/packages/blockchain-components/src/utils/cookies/types.ts
@@ -1,0 +1,8 @@
+import {SHOPIFY_Y, SHOPIFY_S} from './const';
+
+export interface ShopifyCookies {
+  /** Shopify unique user token: Value of `_shopify_y` cookie. */
+  [SHOPIFY_Y]: string;
+  /** Shopify session token: Value of `_shopify_s` cookie. */
+  [SHOPIFY_S]: string;
+}

--- a/packages/blockchain-components/src/utils/cookies/utils.test.ts
+++ b/packages/blockchain-components/src/utils/cookies/utils.test.ts
@@ -1,0 +1,15 @@
+import {ShopifyCookies} from './types';
+import {getShopifyCookies} from './utils';
+
+describe('cookies-utils', () => {
+  describe('getShopifyCookies', () => {
+    it('returns object with SHOPIFY_Y and SHOPIFY_X', () => {
+      const cookie =
+        '_shopify_m=persistent; _y=44c60bb0-577c-4901-874c-92cb323fccf1; _shopify_y=44c60bb0-577c-4901-874c-92cb323fccf1; _shopify_y=44c60bb0-577c-4901-874c-92cb323fccf1; _tracking_consent={"lim":["GDPR"],"v":"2.0","con":{"GDPR":""},"reg":"CCPA"}; _shopify_s=a797b9ef-C0E7-4536-18BA-2828BA504882';
+      expect(getShopifyCookies(cookie)).toMatchObject<ShopifyCookies>({
+        _shopify_y: '44c60bb0-577c-4901-874c-92cb323fccf1',
+        _shopify_s: 'a797b9ef-C0E7-4536-18BA-2828BA504882',
+      });
+    });
+  });
+});

--- a/packages/blockchain-components/src/utils/cookies/utils.ts
+++ b/packages/blockchain-components/src/utils/cookies/utils.ts
@@ -1,0 +1,12 @@
+import {parse} from 'worktop/cookie';
+
+import {SHOPIFY_S, SHOPIFY_Y} from './const';
+import {ShopifyCookies} from './types';
+
+export const getShopifyCookies = (cookies: string): ShopifyCookies => {
+  const cookieData = parse(cookies);
+  return {
+    [SHOPIFY_Y]: cookieData[SHOPIFY_Y] || '',
+    [SHOPIFY_S]: cookieData[SHOPIFY_S] || '',
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10595,6 +10595,11 @@ regexp.prototype.flags@^1.4.3:
     define-properties "^1.1.3"
     functions-have-names "^1.2.2"
 
+regexparam@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexparam/-/regexparam-2.0.1.tgz#c912f5dae371e3798100b3c9ce22b7414d0889fa"
+  integrity sha512-zRgSaYemnNYxUv+/5SeoHI0eJIgTL/A2pUtXUPLHQxUldagouJ9p+K6IbIZ/JiQuCEv2E2B1O11SjVQy3aMCkw==
+
 regexpp@^3.0.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
@@ -12348,6 +12353,13 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
+
+worktop@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/worktop/-/worktop-0.7.3.tgz#7dbf85f0add229cf261759bf3855820814b99cba"
+  integrity sha512-WBHP1hk8pLP7ahAw13fugDWcO0SUAOiCD6DHT/bfLWoCIA/PL9u7GKdudT2nGZ8EGR1APbGCAI6ZzKG1+X+PnQ==
+  dependencies:
+    regexparam "^2.0.0"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
## ℹ️ What is the context for these changes?
Adds `util` functions for Shopify cookies. We want to send the session and user token in the analytics published events, these new utils will allow us to get that info.

## 🕹️ Demonstration
No demonstration for this PR. We are only adding functions, not calling them yet.

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
Green CI 🍏 

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [ ] ~Tested on multiple browsers~ N/A
- [ ] ~Tested for accessibility~ N/A
- [x] Includes unit tests
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
