### PR TITLE
Add wallet extensibility changes to CRA example app

### DIFF
--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -23,10 +23,12 @@
     "tsconfig": "file:../../packages/tsconfig"
   },
   "resolutions": {
+    "@shopify/blockchain-components": "file:../../packages/blockchain-components",
     "@shopify/gate-context-client": "file:../../packages/gate-context-client"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "bundle-packages": "cd ../../ && yarn build --filter='!playground'",
+    "start": "yarn bundle-packages && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/examples/cra/src/connect-wallet-config.ts
+++ b/examples/cra/src/connect-wallet-config.ts
@@ -1,4 +1,4 @@
-import {getDefaultConnectors} from '@shopify/connect-wallet';
+import {buildConnectors} from '@shopify/connect-wallet';
 import {configureChains, createClient} from 'wagmi';
 import {mainnet} from 'wagmi/chains';
 // import {alchemyProvider} from 'wagmi/providers/alchemy';
@@ -12,13 +12,13 @@ const {chains, provider, webSocketProvider} = configureChains(
   ],
 );
 
-const {connectors} = getDefaultConnectors({chains});
+const {connectors, wagmiConnectors} = buildConnectors({chains});
 
 const client = createClient({
   autoConnect: true,
-  connectors,
+  connectors: wagmiConnectors,
   provider,
   webSocketProvider,
 });
 
-export {chains, client};
+export {chains, client, connectors};

--- a/examples/cra/src/index.tsx
+++ b/examples/cra/src/index.tsx
@@ -5,7 +5,7 @@ import {WagmiConfig} from 'wagmi';
 
 import './index.css';
 import App from './App';
-import {chains, client} from './connect-wallet-config';
+import {chains, client, connectors} from './connect-wallet-config';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(
@@ -14,7 +14,7 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <WagmiConfig client={client}>
-      <ConnectWalletProvider chains={chains}>
+      <ConnectWalletProvider chains={chains} connectors={connectors}>
         <App />
       </ConnectWalletProvider>
     </WagmiConfig>

--- a/packages/connect-wallet/src/types/connector.ts
+++ b/packages/connect-wallet/src/types/connector.ts
@@ -1,5 +1,4 @@
-import {Chain} from '@wagmi/core';
-import {Connector as WagmiConnector} from 'wagmi';
+import {Chain, Connector as WagmiConnector} from 'wagmi';
 import {InjectedConnector} from 'wagmi/connectors/injected';
 import {WalletConnectConnector} from 'wagmi/connectors/walletConnect';
 


### PR DESCRIPTION
## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

Refactors the CRA example app to use the new `buildConnectors` function and to pass `connectors` to the `ConnectWalletProvider`. The changes are the same that exist in our [playground](https://github.com/Shopify/blockchain-components/tree/main/apps/playground). 

## 🕹️ Demonstration

https://user-images.githubusercontent.com/18248358/225454608-e65bcb60-20e8-4cb6-9cd2-a4a1f4a12783.mov

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?

- Enter the `examples/cra` directory 
- Run `yarn start`
- Verify that the app runs and that you can connect your wallet

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] ~~Tested on mobile~~
- [x] Tested on multiple browsers
- [x] ~~Tested for accessibility~~
- [x] ~~Includes unit tests~~
- [x] ~~Updated relevant documentation for the changes (if necessary)~~
