### PR TITLE
Add wallet extensibility changes to Nextjs example app

### DIFF
--- a/examples/nextjs/connect-wallet-config.ts
+++ b/examples/nextjs/connect-wallet-config.ts
@@ -1,4 +1,4 @@
-import {getDefaultConnectors} from '@shopify/connect-wallet';
+import {buildConnectors} from '@shopify/connect-wallet';
 import {configureChains, createClient} from 'wagmi';
 import {mainnet} from 'wagmi/chains';
 // import {alchemyProvider} from 'wagmi/providers/alchemy';
@@ -12,13 +12,13 @@ const {chains, provider, webSocketProvider} = configureChains(
   ],
 );
 
-const {connectors} = getDefaultConnectors({chains});
+const {connectors, wagmiConnectors} = buildConnectors({chains});
 
 const client = createClient({
   autoConnect: true,
-  connectors,
+  connectors: wagmiConnectors,
   provider,
   webSocketProvider,
 });
 
-export {chains, client};
+export {chains, client, connectors};

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "bundle-packages": "cd ../../ && yarn build --filter='!playground'",
+    "dev": "yarn bundle-packages && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -26,6 +27,7 @@
     "tsconfig": "file:../../packages/tsconfig"
   },
   "resolutions": {
+    "@shopify/blockchain-components": "file:../../packages/blockchain-components",
     "@shopify/gate-context-client": "file:../../packages/gate-context-client"
   }
 }

--- a/examples/nextjs/pages/_app.tsx
+++ b/examples/nextjs/pages/_app.tsx
@@ -4,12 +4,12 @@ import {WagmiConfig} from 'wagmi';
 
 import '../styles/globals.css';
 
-import {chains, client} from '../connect-wallet-config';
+import {chains, client, connectors} from '../connect-wallet-config';
 
 export default function App({Component, pageProps}: AppProps) {
   return (
     <WagmiConfig client={client}>
-      <ConnectWalletProvider chains={chains}>
+      <ConnectWalletProvider chains={chains} connectors={connectors}>
         <Component {...pageProps} />
       </ConnectWalletProvider>
     </WagmiConfig>


### PR DESCRIPTION
## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

Refactors the Nextjs example app to use the new `buildConnectors` function and to pass `connectors` to the `ConnectWalletProvider`. The changes are the same that exist in our [playground](https://github.com/Shopify/blockchain-components/tree/main/apps/playground). 

## 🕹️ Demonstration

https://user-images.githubusercontent.com/18248358/225466443-21e1eb5a-f32e-43c8-b77e-d89f082a4ae5.mov

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?

- Enter the `examples/nextjs` directory 
- Run `yarn dev`
- Verify that the app runs and that you can connect your wallet

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] ~~Tested on mobile~~
- [x] Tested on multiple browsers
- [x] ~~Tested for accessibility~~
- [x] ~~Includes unit tests~~
- [x] ~~Updated relevant documentation for the changes (if necessary)~~
