### PR TITLE
Refactor `collectionAddress` -> `contractAddress`

### DIFF
--- a/.changeset/ninety-starfishes-admire.md
+++ b/.changeset/ninety-starfishes-admire.md
@@ -1,0 +1,9 @@
+---
+'@shopify/tokengate': major
+---
+
+Renaming instances of `collectionAddress` to `contractAddress` for consistency with Gates API and for more descriptive naming.
+
+To update your project to align with these changes, replace all occurances of `collectionAddress` to `contractAddress`.
+
+For more information, see https://shopify.dev/docs/api/blockchain/components/tokengate.md

--- a/packages/tokengate/src/components/Tokengate/utils.spec.ts
+++ b/packages/tokengate/src/components/Tokengate/utils.spec.ts
@@ -310,13 +310,13 @@ describe('Tokengate - utils', () => {
               logic: 'ANY',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0x123',
+                contractAddress: '0x123',
               }),
             ],
           }),
@@ -332,13 +332,13 @@ describe('Tokengate - utils', () => {
               logic: 'ANY',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0xabc',
+                contractAddress: '0xabc',
               }),
             ],
           }),
@@ -354,16 +354,16 @@ describe('Tokengate - utils', () => {
               logic: 'ANY',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
                 ConditionFixture({
-                  collectionAddress: '0xefg',
+                  contractAddress: '0xefg',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0xefg',
+                contractAddress: '0xefg',
               }),
             ],
           }),
@@ -379,16 +379,16 @@ describe('Tokengate - utils', () => {
               logic: 'ANY',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
                 ConditionFixture({
-                  collectionAddress: '0xefg',
+                  contractAddress: '0xefg',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0x123',
+                contractAddress: '0x123',
               }),
             ],
           }),
@@ -424,13 +424,13 @@ describe('Tokengate - utils', () => {
               logic: 'ALL',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0x123',
+                contractAddress: '0x123',
               }),
             ],
           }),
@@ -446,13 +446,13 @@ describe('Tokengate - utils', () => {
               logic: 'ALL',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0xabc',
+                contractAddress: '0xabc',
               }),
             ],
           }),
@@ -468,16 +468,16 @@ describe('Tokengate - utils', () => {
               logic: 'ALL',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
                 ConditionFixture({
-                  collectionAddress: '0xefg',
+                  contractAddress: '0xefg',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0xefg',
+                contractAddress: '0xefg',
               }),
             ],
           }),
@@ -493,19 +493,19 @@ describe('Tokengate - utils', () => {
               logic: 'ALL',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
                 ConditionFixture({
-                  collectionAddress: '0xefg',
+                  contractAddress: '0xefg',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0xabc',
+                contractAddress: '0xabc',
               }),
               UnlockingTokenFixture({
-                collectionAddress: '0xefg',
+                contractAddress: '0xefg',
               }),
             ],
           }),
@@ -521,19 +521,19 @@ describe('Tokengate - utils', () => {
               logic: 'ALL',
               conditions: [
                 ConditionFixture({
-                  collectionAddress: '0xabc',
+                  contractAddress: '0xabc',
                 }),
                 ConditionFixture({
-                  collectionAddress: '0xefg',
+                  contractAddress: '0xefg',
                 }),
               ],
             }),
             unlockingTokens: [
               UnlockingTokenFixture({
-                collectionAddress: '0x123',
+                contractAddress: '0x123',
               }),
               ConditionFixture({
-                collectionAddress: '0xefg',
+                contractAddress: '0xefg',
               }),
             ],
           }),

--- a/packages/tokengate/src/components/Tokengate/utils.ts
+++ b/packages/tokengate/src/components/Tokengate/utils.ts
@@ -184,8 +184,8 @@ export const calculatedIsLocked = (props: TokengateProps) => {
       Boolean(
         unlockingTokens.find(
           (unlockingToken) =>
-            unlockingToken.collectionAddress.toLowerCase() ===
-            condition.collectionAddress?.toLowerCase(),
+            unlockingToken.contractAddress.toLowerCase() ===
+            condition.contractAddress?.toLowerCase(),
         ),
       ),
   );

--- a/packages/tokengate/src/components/TokengateRequirements/utils.test.tsx
+++ b/packages/tokengate/src/components/TokengateRequirements/utils.test.tsx
@@ -5,13 +5,13 @@ describe('getConditionTitle', () => {
     expect(getConditionTitle({name: 'foo'})).toBe('foo');
   });
 
-  it('returns the formatted collection address when available', () => {
-    expect(getConditionTitle({collectionAddress: '0x1234567890'})).toBe(
+  it('returns the formatted contract address when available', () => {
+    expect(getConditionTitle({contractAddress: '0x1234567890'})).toBe(
       'contract 0x12...7890',
     );
   });
 
-  it('returns blank string when no name or collection address', () => {
+  it('returns blank string when no name or contract address', () => {
     expect(getConditionTitle({})).toBe('');
   });
 });

--- a/packages/tokengate/src/components/TokengateRequirements/utils.tsx
+++ b/packages/tokengate/src/components/TokengateRequirements/utils.tsx
@@ -40,12 +40,12 @@ export const mapRequirementsToTokenListProps = ({
     };
   });
 
-export const getConditionTitle = ({name, collectionAddress}: Condition) => {
+export const getConditionTitle = ({name, contractAddress}: Condition) => {
   if (name) return name;
 
-  if (!collectionAddress) return '';
+  if (!contractAddress) return '';
 
-  return `contract ${formatWalletAddress(collectionAddress)}`;
+  return `contract ${formatWalletAddress(contractAddress)}`;
 };
 
 export const findUnlockingTokenForCondition = ({
@@ -57,5 +57,5 @@ export const findUnlockingTokenForCondition = ({
 }) =>
   unlockingTokens?.find(
     (unlockingToken) =>
-      unlockingToken.collectionAddress === condition.collectionAddress,
+      unlockingToken.contractAddress === condition.contractAddress,
   );

--- a/packages/tokengate/src/fixtures/Condition.ts
+++ b/packages/tokengate/src/fixtures/Condition.ts
@@ -6,7 +6,7 @@ export const ConditionFixture = (customProps?: DeepPartial<Condition>) =>
   deepMerge(
     {
       name: 'CryptoPunks',
-      collectionAddress: '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB',
+      contractAddress: '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB',
       imageUrl:
         'https://i.seadn.io/gae/BdxvLseXcfl57BiuQcQYdJ64v-aI8din7WPk0Pgo3qQFhAUH-B6i-dCqqc_mCkRIzULmwzwecnohLhrcH8A9mpWIZqA7ygc52Sr81hE?auto=format&w=384',
     },
@@ -19,6 +19,6 @@ export const ConditionArrayFixture = () => [
     name: 'Moonbirds',
     imageUrl:
       'https://i.seadn.io/gae/H-eyNE1MwL5ohL-tCfn_Xa1Sl9M9B4612tLYeUlQubzt4ewhr4huJIR5OLuyO3Z5PpJFSwdm7rq-TikAh7f5eUw338A2cy6HRH75?auto=format&w=384',
-    collectionAddress: '0x23581767a106ae21c074b2276D25e5C3e136a68b',
+    contractAddress: '0x23581767a106ae21c074b2276D25e5C3e136a68b',
   }),
 ];

--- a/packages/tokengate/src/fixtures/UnlockingToken.ts
+++ b/packages/tokengate/src/fixtures/UnlockingToken.ts
@@ -8,7 +8,7 @@ export enum UnlockingTokenFixtureType {
 }
 
 const CryptoPunksProps = {
-  collectionAddress: '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB',
+  contractAddress: '0xb47e3cd837dDF8e4c57F05d70Ab865de6e193BBB',
   collectionName: 'CryptoPunks',
   imageUrl:
     'https://i.seadn.io/gae/ZWEV7BBCssLj4I2XD9zlPjbPTMcmR6gM9dSl96WqFHS02o4mucLaNt8ZTvSfng3wHfB40W9Md8lrQ-CSrBYIlAFa?auto=format&w=1000',
@@ -16,7 +16,7 @@ const CryptoPunksProps = {
 };
 
 const MoonbirdsProps = {
-  collectionAddress: '0x23581767a106ae21c074b2276D25e5C3e136a68b',
+  contractAddress: '0x23581767a106ae21c074b2276D25e5C3e136a68b',
   collectionName: 'Moonbirds',
   imageUrl:
     'https://looksrare.mo.cloudinary.net/0x23581767a106ae21c074b2276D25e5C3e136a68b/0x66936fd157d67f7f12155b72f323b413ab7694f4d38d800b330b7ad16bc41f4d?resource_type=image&f=auto&c=limit&w=1600&q=auto:best',

--- a/packages/tokengate/src/types.ts
+++ b/packages/tokengate/src/types.ts
@@ -3,7 +3,7 @@ import {ReactNode} from 'react';
 export interface Condition {
   name?: string;
   imageUrl?: string;
-  collectionAddress?: string;
+  contractAddress?: string;
   description?: ReactNode;
 }
 
@@ -16,7 +16,7 @@ export interface UnlockingToken {
   name: string;
   imageUrl: string;
   collectionName: string;
-  collectionAddress: string;
+  contractAddress: string;
   consumedRedemptionLimit?: number;
 }
 

--- a/packages/tokengate/src/utils/adapters/requirements.ts
+++ b/packages/tokengate/src/utils/adapters/requirements.ts
@@ -15,7 +15,7 @@ export const adaptRequirements = (gateRequirement?: {
   return {
     logic: gateRequirement.operator === 'AND' ? 'ALL' : 'ANY',
     conditions: gateRequirement.tokenSeries.map((tokenSeries) => ({
-      collectionAddress: tokenSeries.contractAddress,
+      contractAddress: tokenSeries.contractAddress,
       name: tokenSeries.name,
       imageUrl: tokenSeries.imageUrl,
     })),

--- a/packages/tokengate/src/utils/adapters/unlockingTokens.ts
+++ b/packages/tokengate/src/utils/adapters/unlockingTokens.ts
@@ -16,7 +16,7 @@ const adaptUnlockingToken = (
   name: unlockingToken.token.title,
   imageUrl: unlockingToken.token.mediaUrl,
   collectionName: unlockingToken.token.contractName,
-  collectionAddress: unlockingToken.token.contractAddress,
+  contractAddress: unlockingToken.token.contractAddress,
   consumedRedemptionLimit: unlockingToken.token.consumedOrderLimit,
 });
 


### PR DESCRIPTION
## ℹ️ What is the context for these changes?

Update tokengate components to use contractAddress instead of collectionAddress

As a 1P developer, I want use `contractAddress` consistently throughout the backend and frontend, so that I reason about the code without coercing values.

## 🕹️ Demonstration

**Playground**
https://user-images.githubusercontent.com/18248358/225751290-2dcc6a55-9f85-42dd-9172-926bb85867d1.mov

## 🎩 How can this be tophatted?


## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] ~~Tested on mobile~~
- [x] Tested on multiple browsers
- [x] ~~Tested for accessibility~~
- [x] ~~Includes unit tests~~
- [x] ~~Updated relevant documentation for the changes (if necessary)~~ Will be done POST-MERGE
