### PR TITLE
[delegate-cash] Add redux logic for supporting delegate.cash delegations

### DIFF
--- a/.changeset/kind-pumpkins-accept.md
+++ b/.changeset/kind-pumpkins-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/connect-wallet': minor
+---
+
+[delegate-cash] Add redux logic for supporting delegate.cash delegations

--- a/packages/connect-wallet/package.json
+++ b/packages/connect-wallet/package.json
@@ -47,6 +47,7 @@
     "@shopify/blockchain-components": "*",
     "@shopify/gate-context-client": "*",
     "@storybook/react": "^7.0.0-beta.52",
+    "delegatecash": "^0.4.1",
     "framer-motion": "^8.5.0",
     "i18next": "^22.4.9",
     "qrcode": "^1.5.1",

--- a/packages/connect-wallet/src/hooks/useMiddleware.ts
+++ b/packages/connect-wallet/src/hooks/useMiddleware.ts
@@ -6,6 +6,7 @@ import {
   addWallet,
   attributeOrder,
   fetchEns,
+  fetchDelegations,
   setActiveWallet,
   setPendingWallet,
 } from '../slices/walletSlice';
@@ -142,6 +143,7 @@ export const useMiddleware = ({
           fetchEns({address: wallet.address, chain: {...rest}, provider}),
         );
       }
+      state.dispatch(fetchDelegations(wallet.address));
     });
 
     return dispatch(listener);

--- a/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
@@ -1,5 +1,6 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 import {DelegateCash} from 'delegatecash';
+import {Address} from 'wagmi';
 
 export const fetchDelegations = createAsyncThunk(
   'wallet/fetchDelegations',
@@ -17,14 +18,14 @@ export const fetchDelegations = createAsyncThunk(
     );
 
     // Get only the vault wallet addresses
-    const delegationsWalletAddresses = delegationsFilteredByAllType.map(
-      (delegation) => delegation.vault,
+    const vaults = delegationsFilteredByAllType.map(
+      (delegation) => delegation.vault as Address,
     );
 
-    if (delegationsWalletAddresses.length) {
+    if (vaults.length) {
       return thunkApi.fulfillWithValue({
         address: walletAddress,
-        delegationsWalletAddresses,
+        vaults,
       });
     }
   },

--- a/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
@@ -1,0 +1,31 @@
+import {createAsyncThunk} from '@reduxjs/toolkit';
+import {DelegateCash} from 'delegatecash';
+
+export const fetchDelegations = createAsyncThunk(
+  'wallet/fetchDelegations',
+  async (walletAddress: string, thunkApi) => {
+    const delegateCash = new DelegateCash();
+    const delegations = await delegateCash.getDelegationsByDelegate(
+      walletAddress,
+    );
+
+    // Delegation type can be 'ALL', 'CONTRACT', 'TOKEN', or 'NONE'.
+    // For delegation type 'ALL', the vault wallet delegates all actions to the delegate wallet.
+    // We filter by 'ALL' since we only want to handle delegations for the entire wallet.
+    const delegationsFilteredByAllType = delegations.filter(
+      (delegation) => delegation.type === 'ALL',
+    );
+
+    // Get only the vault wallet addresses
+    const delegationsWalletAddresses = delegationsFilteredByAllType.map(
+      (delegation) => delegation.vault,
+    );
+
+    if (delegationsWalletAddresses.length) {
+      return thunkApi.fulfillWithValue({
+        address: walletAddress,
+        delegationsWalletAddresses,
+      });
+    }
+  },
+);

--- a/packages/connect-wallet/src/slices/walletSlice/index.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/index.ts
@@ -1,3 +1,4 @@
 export * from './walletSlice';
 export {attributeOrder} from './attributeOrder';
 export {fetchEns} from './fetchEns';
+export {fetchDelegations} from './delegateCash';

--- a/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
@@ -237,22 +237,24 @@ export const walletSlice = createSlice({
     });
     builder.addCase(fetchDelegations.fulfilled, (state, action) => {
       if (action.payload) {
-        const {address, delegationsWalletAddresses} = action.payload;
+        const {address, vaults} = action.payload;
 
         const connectedWallet = state.connectedWallets.find(
-          (wallet) => wallet.address === address,
+          (wallet) =>
+            wallet.address.toLocaleLowerCase() === address.toLocaleLowerCase(),
         );
 
         // Update wallet in 'connectedWallets' state
         if (connectedWallet) {
-          connectedWallet.delegationsWalletAddresses =
-            delegationsWalletAddresses;
+          connectedWallet.vaults = vaults;
         }
 
         // Update wallet in 'activeWallet' state
-        if (state.activeWallet?.address === address) {
-          state.activeWallet.delegationsWalletAddresses =
-            delegationsWalletAddresses;
+        if (
+          state.activeWallet?.address.toLocaleLowerCase() ===
+          address.toLocaleLowerCase()
+        ) {
+          state.activeWallet.vaults = vaults;
         }
       }
     });

--- a/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
@@ -8,6 +8,7 @@ import {SignatureResponse, Wallet} from '../../types/wallet';
 import {ConnectWalletError} from '../../utils/error';
 
 import {fetchEns} from './fetchEns';
+import {fetchDelegations} from './delegateCash';
 
 export interface WalletSliceType {
   activeWallet?: Wallet;
@@ -233,6 +234,27 @@ export const walletSlice = createSlice({
       }
 
       throw new ConnectWalletError(errorMessage);
+    });
+    builder.addCase(fetchDelegations.fulfilled, (state, action) => {
+      if (action.payload) {
+        const {address, delegationsWalletAddresses} = action.payload;
+
+        const connectedWallet = state.connectedWallets.find(
+          (wallet) => wallet.address === address,
+        );
+
+        // Update wallet in 'connectedWallets' state
+        if (connectedWallet) {
+          connectedWallet.delegationsWalletAddresses =
+            delegationsWalletAddresses;
+        }
+
+        // Update wallet in 'activeWallet' state
+        if (state.activeWallet?.address === address) {
+          state.activeWallet.delegationsWalletAddresses =
+            delegationsWalletAddresses;
+        }
+      }
     });
   },
 });

--- a/packages/connect-wallet/src/types/wallet.ts
+++ b/packages/connect-wallet/src/types/wallet.ts
@@ -50,4 +50,9 @@ export interface Wallet extends ConnectedWallet {
    * ISO datetime string in which the wallet was verified.
    */
   signedOn?: string;
+  /**
+   * A list of "vault" proxy wallet addresses delegations that have delegated ownership to this wallet.
+   * You can treat these addresses as being controlled by the same entity as this wallet.
+   */
+  delegationsWalletAddresses?: string[];
 }

--- a/packages/connect-wallet/src/types/wallet.ts
+++ b/packages/connect-wallet/src/types/wallet.ts
@@ -26,6 +26,11 @@ export interface ConnectedWallet {
    * This will only be filled when an Alchemy or Infura provider are present.
    */
   displayName?: string;
+  /**
+   * A list of "vault" proxy wallet addresses that have delegated ownership to this wallet.
+   * You can treat these addresses as being controlled by the same entity as this wallet.
+   */
+  vaults?: Address[];
 }
 
 export interface SignatureResponse {
@@ -50,9 +55,4 @@ export interface Wallet extends ConnectedWallet {
    * ISO datetime string in which the wallet was verified.
    */
   signedOn?: string;
-  /**
-   * A list of "vault" proxy wallet addresses delegations that have delegated ownership to this wallet.
-   * You can treat these addresses as being controlled by the same entity as this wallet.
-   */
-  delegationsWalletAddresses?: string[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6067,6 +6067,13 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
+delegatecash@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/delegatecash/-/delegatecash-0.4.1.tgz#0ff5a522eac5b75a9f4f02a366b572cf24470b05"
+  integrity sha512-udA3nGyCLnPacoekeeIdDO6o3aRzM9imGuaOilPOOExpCz8OLHKNtKlwHZg58Wjh6VfRPKD1EsQeI0ltCvKL2w==
+  dependencies:
+    ethers "^5.7.1"
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -7090,7 +7097,7 @@ ethereumjs-util@^6.0.0:
     ethjs-util "0.1.6"
     rlp "^2.2.3"
 
-ethers@^5.7.2:
+ethers@^5.7.1, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
Implements support for [delegate.cash](https://delegate.cash) to allow linking a hot ("delegate") wallet which then looks up associated cold ("vault") wallet(s) that have been proven to be owned by the same entity.

I'll be doing this in different PRs based on the original PR: https://github.com/Shopify/blockchain-components/pull/13

## ℹ️ What is the context for these changes?
This PR adds the redux logic for supporting delegations.

## 🕹️ Demonstration
![17-31-ad9o6-cr6zz](https://user-images.githubusercontent.com/8977776/226057291-d599a965-d248-423c-8681-190c6890ad5e.gif)

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

Can be 🎩 in Replit: https://replit.com/@caropinzonsilva/FamousNonstopAudit
For some reason, the QR codes are not working, so you would need to use Metamask.

- Connect your hot wallet with delegation.
- In the console.log, check the latest redux state
- You should see the `delegationsWalletAddresses` in both the connected wallets and active wallet state:
<img width="1508" alt="17-28-1finm-why0h" src="https://user-images.githubusercontent.com/8977776/226056943-87ced103-15fa-414b-946c-d775e843882a.png">


## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [x] Tested on multiple browsers
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
