### PR TITLE
[delegate-cash] Add `enableDelegateCash` prop to ConnectWalletProvider

### DIFF
--- a/.changeset/tidy-deers-agree.md
+++ b/.changeset/tidy-deers-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/connect-wallet': minor
+---
+
+[delegate-cash] Add allowDelegateCashSupport prop to ConnectWalletProvider

--- a/.changeset/tidy-deers-agree.md
+++ b/.changeset/tidy-deers-agree.md
@@ -2,4 +2,4 @@
 '@shopify/connect-wallet': minor
 ---
 
-[delegate-cash] Add allowDelegateCashSupport prop to ConnectWalletProvider
+[delegate-cash] Add enableDelegateCash prop to ConnectWalletProvider

--- a/apps/playground/src/index.tsx
+++ b/apps/playground/src/index.tsx
@@ -44,9 +44,9 @@ window.playground = {
           <AnalyticsListener />
           <WagmiConfig client={client}>
             <ConnectWalletProvider
-              allowDelegateCashSupport
               chains={chains}
               connectors={connectors}
+              enableDelegateCash
               orderAttributionMode="ignoreErrors"
             >
               <App

--- a/apps/playground/src/index.tsx
+++ b/apps/playground/src/index.tsx
@@ -44,6 +44,7 @@ window.playground = {
           <AnalyticsListener />
           <WagmiConfig client={client}>
             <ConnectWalletProvider
+              allowDelegateCashSupport
               chains={chains}
               connectors={connectors}
               orderAttributionMode="ignoreErrors"

--- a/packages/connect-wallet/src/hooks/useMiddleware.ts
+++ b/packages/connect-wallet/src/hooks/useMiddleware.ts
@@ -17,14 +17,14 @@ import {SignatureResponse, Wallet} from '../types/wallet';
 import {useAppDispatch, useAppSelector} from './useAppState';
 
 interface UseMiddlewareProps {
-  allowDelegateCashSupport?: boolean;
+  enableDelegateCash?: boolean;
   orderAttributionMode: OrderAttributionMode;
   requestSignature: (wallet: Wallet) => Promise<SignatureResponse | undefined>;
   requireSignature?: boolean;
 }
 
 export const useMiddleware = ({
-  allowDelegateCashSupport,
+  enableDelegateCash,
   orderAttributionMode,
   requestSignature,
   requireSignature,
@@ -145,17 +145,11 @@ export const useMiddleware = ({
           fetchEns({address: wallet.address, chain: {...rest}, provider}),
         );
       }
-      if (allowDelegateCashSupport) {
+      if (enableDelegateCash) {
         state.dispatch(fetchDelegations(wallet.address));
       }
     });
 
     return dispatch(listener);
-  }, [
-    allowDelegateCashSupport,
-    chain,
-    dispatch,
-    orderAttributionMode,
-    provider,
-  ]);
+  }, [chain, dispatch, enableDelegateCash, orderAttributionMode, provider]);
 };

--- a/packages/connect-wallet/src/hooks/useMiddleware.ts
+++ b/packages/connect-wallet/src/hooks/useMiddleware.ts
@@ -17,12 +17,14 @@ import {SignatureResponse, Wallet} from '../types/wallet';
 import {useAppDispatch, useAppSelector} from './useAppState';
 
 interface UseMiddlewareProps {
+  allowDelegateCashSupport?: boolean;
   orderAttributionMode: OrderAttributionMode;
   requestSignature: (wallet: Wallet) => Promise<SignatureResponse | undefined>;
   requireSignature?: boolean;
 }
 
 export const useMiddleware = ({
+  allowDelegateCashSupport,
   orderAttributionMode,
   requestSignature,
   requireSignature,
@@ -143,9 +145,17 @@ export const useMiddleware = ({
           fetchEns({address: wallet.address, chain: {...rest}, provider}),
         );
       }
-      state.dispatch(fetchDelegations(wallet.address));
+      if (allowDelegateCashSupport) {
+        state.dispatch(fetchDelegations(wallet.address));
+      }
     });
 
     return dispatch(listener);
-  }, [chain, dispatch, orderAttributionMode, provider]);
+  }, [
+    allowDelegateCashSupport,
+    chain,
+    dispatch,
+    orderAttributionMode,
+    provider,
+  ]);
 };

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/context.tsx
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/context.tsx
@@ -7,18 +7,18 @@ import {OrderAttributionMode} from '../../types/orderAttribution';
 import {StatementGenerator} from './types';
 
 export interface ConnectWalletProviderValue {
-  allowDelegateCashSupport?: boolean;
   chains: Chain[];
   connectors: Connector[];
+  enableDelegateCash?: boolean;
   requireSignature?: boolean;
   statementGenerator?: StatementGenerator;
   orderAttributionMode: OrderAttributionMode;
 }
 
 const defaultContextValue: ConnectWalletProviderValue = {
-  allowDelegateCashSupport: true,
   chains: [],
   connectors: [],
+  enableDelegateCash: true,
   requireSignature: true,
   orderAttributionMode: 'required',
 };

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/context.tsx
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/context.tsx
@@ -7,6 +7,7 @@ import {OrderAttributionMode} from '../../types/orderAttribution';
 import {StatementGenerator} from './types';
 
 export interface ConnectWalletProviderValue {
+  allowDelegateCashSupport?: boolean;
   chains: Chain[];
   connectors: Connector[];
   requireSignature?: boolean;
@@ -15,6 +16,7 @@ export interface ConnectWalletProviderValue {
 }
 
 const defaultContextValue: ConnectWalletProviderValue = {
+  allowDelegateCashSupport: true,
   chains: [],
   connectors: [],
   requireSignature: true,

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/provider.tsx
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/provider.tsx
@@ -15,10 +15,10 @@ import {ConnectWalletContext, ConnectWalletProviderValue} from './context';
 import {ProviderProps} from './types';
 
 export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
-  allowDelegateCashSupport = true,
   chains,
   connectors,
   children,
+  enableDelegateCash = true,
   requireSignature = true,
   orderAttributionMode = 'required',
   statementGenerator,
@@ -36,7 +36,7 @@ export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
     }
 
     return {
-      allowDelegateCashSupport,
+      enableDelegateCash,
       chains,
       connectors: contextualConnectors,
       requireSignature,
@@ -44,7 +44,7 @@ export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
       orderAttributionMode,
     };
   }, [
-    allowDelegateCashSupport,
+    enableDelegateCash,
     chains,
     connectors,
     requireSignature,

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/provider.tsx
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/provider.tsx
@@ -15,6 +15,7 @@ import {ConnectWalletContext, ConnectWalletProviderValue} from './context';
 import {ProviderProps} from './types';
 
 export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
+  allowDelegateCashSupport = true,
   chains,
   connectors,
   children,
@@ -35,6 +36,7 @@ export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
     }
 
     return {
+      allowDelegateCashSupport,
       chains,
       connectors: contextualConnectors,
       requireSignature,
@@ -42,6 +44,7 @@ export const ConnectWalletProvider: FC<PropsWithChildren<ProviderProps>> = ({
       orderAttributionMode,
     };
   }, [
+    allowDelegateCashSupport,
     chains,
     connectors,
     requireSignature,

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/types.ts
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/types.ts
@@ -58,8 +58,8 @@ interface OrderAttributionModeProps {
   orderAttributionMode?: OrderAttributionMode;
 }
 
-interface AllowDelegateCashSupportProps {
-  allowDelegateCashSupport?: boolean;
+interface EnableDelegateCashProps {
+  enableDelegateCash?: boolean;
 }
 
 export type ProviderProps = (
@@ -67,4 +67,4 @@ export type ProviderProps = (
   | SignatureNotRequiredProps
 ) &
   OrderAttributionModeProps &
-  AllowDelegateCashSupportProps;
+  EnableDelegateCashProps;

--- a/packages/connect-wallet/src/providers/ConnectWalletProvider/types.ts
+++ b/packages/connect-wallet/src/providers/ConnectWalletProvider/types.ts
@@ -58,8 +58,13 @@ interface OrderAttributionModeProps {
   orderAttributionMode?: OrderAttributionMode;
 }
 
+interface AllowDelegateCashSupportProps {
+  allowDelegateCashSupport?: boolean;
+}
+
 export type ProviderProps = (
   | SignatureRequiredProps
   | SignatureNotRequiredProps
 ) &
-  OrderAttributionModeProps;
+  OrderAttributionModeProps &
+  AllowDelegateCashSupportProps;

--- a/packages/connect-wallet/src/providers/ModalProvider/provider.tsx
+++ b/packages/connect-wallet/src/providers/ModalProvider/provider.tsx
@@ -29,7 +29,7 @@ export const ModalProvider: React.FC<PropsWithChildren> = ({children}) => {
   const {pendingConnector, pendingWallet} = useAppSelector(
     (state) => state.wallet,
   );
-  const {allowDelegateCashSupport, requireSignature, orderAttributionMode} =
+  const {enableDelegateCash, requireSignature, orderAttributionMode} =
     useContext(ConnectWalletContext);
   const {disconnect} = useDisconnect();
   const {signing, signMessage} = useSyncSignMessage();
@@ -213,7 +213,7 @@ export const ModalProvider: React.FC<PropsWithChildren> = ({children}) => {
   });
 
   useMiddleware({
-    allowDelegateCashSupport,
+    enableDelegateCash,
     orderAttributionMode,
     requestSignature,
     requireSignature,

--- a/packages/connect-wallet/src/providers/ModalProvider/provider.tsx
+++ b/packages/connect-wallet/src/providers/ModalProvider/provider.tsx
@@ -29,7 +29,7 @@ export const ModalProvider: React.FC<PropsWithChildren> = ({children}) => {
   const {pendingConnector, pendingWallet} = useAppSelector(
     (state) => state.wallet,
   );
-  const {requireSignature, orderAttributionMode} =
+  const {allowDelegateCashSupport, requireSignature, orderAttributionMode} =
     useContext(ConnectWalletContext);
   const {disconnect} = useDisconnect();
   const {signing, signMessage} = useSyncSignMessage();
@@ -212,7 +212,12 @@ export const ModalProvider: React.FC<PropsWithChildren> = ({children}) => {
     },
   });
 
-  useMiddleware({orderAttributionMode, requestSignature, requireSignature});
+  useMiddleware({
+    allowDelegateCashSupport,
+    orderAttributionMode,
+    requestSignature,
+    requireSignature,
+  });
 
   const contextValue: ModalProviderValue = useMemo(() => {
     return {


### PR DESCRIPTION
Implements support for [delegate.cash](https://delegate.cash) to allow linking a hot ("delegate") wallet which then looks up associated cold ("vault") wallet(s) that have been proven to be owned by the same entity.

I'll be doing this in different PRs based on the original PR: https://github.com/Shopify/blockchain-components/pull/13

## ℹ️ What is the context for these changes?
This PR adds a new prop `enableDelegateCash` to the `ConnectWalletProvider` that allows the user to disable the delegate cash support. I'm allowing it by default.

## 🕹️ Demonstration
![17-04-76lbt-ocw9p](https://user-images.githubusercontent.com/8977776/226061313-97293e44-611c-4311-b090-68a99ed04a70.gif)


<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->
Replit code: https://replit.com/@caropinzonsilva/UnfinishedMeagerPlans
Replit preview: https://unfinishedmeagerplans.caropinzonsilva.repl.co/

- In `ConnectWalletProvider`, set prop `allowDelegateCashSupport` to `true`
- Connect your wallet
- You should see the fetch delegations action getting called
- You should see the `delegationsWalletAddresses` in both the connected wallets and active wallet state (if you have delegations)

- In `ConnectWalletProvider`, set prop `allowDelegateCashSupport` to `false`
- Connect your wallet
- You should NOT see the fetch delegations action getting called
- You should NOT see the `delegationsWalletAddresses` in both the connected wallets and active wallet state

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [x] Tested on multiple browsers
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
