### PR TITLE
Refactor package READMEs to link to shopify.dev docs

### DIFF
--- a/packages/connect-wallet/README.md
+++ b/packages/connect-wallet/README.md
@@ -4,22 +4,15 @@
 
 The `@shopify/connect-wallet` package provides a standard way of connecting wallets and signing messages on Shopify storefronts. For more in-depth information, [read the complete documentation](https://shopify.dev/api/blockchain/components/connect-wallet).
 
-## Get started
-
-To get started with using `@shopify/connect-wallet` you need to follow these steps
-
-1. [Installation](#installation)
-1. [Client configuration](#client-configuration)
-1. [App provider setup](#app-provider-setup)
-1. [Adding the `ConnectButton` component to your app](#adding-the-connectbutton-component-to-your-app)
-
-### Installation
+## Installation
 
 Install the `shopify/connect-wallet` package and its wagmi + ethers peer dependencies.
 
 ```bash
 yarn add @shopify/connect-wallet ethers wagmi
 ```
+
+## Documentation
 
 ### Client configuration
 
@@ -63,6 +56,7 @@ Let's begin using the configured client and chains. In your app's entry point, (
 
 ```tsx
 import {ConnectWalletProvider} from '@shopify/connect-wallet';
+import '@shopify/connect-wallet/styles.css';
 import {WagmiConfig} from 'wagmi';
 
 import {chains, client, connectors} from './connect-wallet-config'
@@ -98,22 +92,16 @@ export const Header = () => {
 }
 ```
 
-## Additional setup
+For further detailed documentation, [visit shopify.dev](https://shopify.dev/docs/api/blockchain/components/connect-wallet).
 
-Additional setup might be required depending on the tooling of your project.
-
-### Polyfills
-
-If you're using a bundler such as [Vite](https://vitejs.dev/) which doesn't provide Node polyfills, you will need to polyfill `global`, `Buffer`, and `process`. Below is a list of plugins that you can use for polyfills:
-
-- [`@esbuild-plugins/node-globals-polyfill`](https://github.com/remorses/esbuild-plugins)
-- [`vite-plugin-node-stdlib-browser`](https://github.com/sodatea/vite-plugin-node-stdlib-browser)
-- [`vite-plugin-node-polyfills`](https://github.com/voracious/vite-plugin-node-polyfills)
+For examples of component usage, see the [examples folder](https://github.com/Shopify/blockchain-components/tree/main/examples).
 
 ## Contributing
 
 Pull requests are welcome. See the [contribution guidelines](../../.github/contributing.md) for more information.
 
-## Licenses
+## License
 
-- Source code is under the [MIT license](../../LICENSE.md).
+MIT &copy; [Shopify](https://shopify.com/), see [LICENSE.md](LICENSE.md) for details.
+
+[![Shopify Logo Light](../../images/shopify-light.svg#gh-dark-mode-only)![Shopify Logo Dark](../../images/shopify-dark.svg#gh-light-mode-only)](<(https://www.shopify.com/)>)

--- a/packages/gate-context-client/README.md
+++ b/packages/gate-context-client/README.md
@@ -4,7 +4,19 @@
 
 The `gate-context-client` package provides an abstract interface to read and write gate context information. The client writes gate context information for use by [Shopify functions](/docs/api/functions). For example, the client could write a signed message to the context. That message could be validated and processed by a Shopify function in order to apply discounts or block checkout.
 
-## Code example
+## Installation
+
+Install the `shopify/gate-context-client` package.
+
+```bash
+yarn add @shopify/gate-context-client
+```
+
+## Documentation
+
+See the [Tokengating example app tutorial](https://shopify.dev/apps/blockchain/tokengating/build-a-tokengating-app) for further documentation. Specifically, the end of the [Show gates on the storefront using a theme app extension](https://shopify.dev/apps/blockchain/tokengating/build-a-tokengating-app/show-gates-storefront) part about writing an HMAC.
+
+### Code example
 
 ```typescript
 interface Input {
@@ -26,17 +38,7 @@ async function run(data: Input) {
 }
 ```
 
-## Installation
-
-```bash
-yarn add @shopify/gate-context-client
-```
-
-## Get started
-
-See the [Tokengating example app tutorial](https://shopify.dev/apps/blockchain/tokengating/build-a-tokengating-app) for more context, and specifically the end of the [Show gates on the storefront using a theme app extension](https://shopify.dev/apps/blockchain/tokengating/build-a-tokengating-app/show-gates-storefront) part about writing an HMAC.
-
-## Backends
+### Backends
 
 The client is intended to abstract backend details and automatically choose the correct backend where possible. For
 example, for the Online store channel, the Cart Ajax API will be used. The [Cart Ajax API](https://shopify.dev/docs/api/ajax/reference/cart) is the only supported backend right now.
@@ -57,7 +59,7 @@ After writing via the client and inspecting the cart, via `/cart.js`, you'd see 
 }
 ```
 
-## `shopifyGateContextGenerator`
+### `shopifyGateContextGenerator`
 
 This is an async transformation function that will get called before the write to the
 backend occurs, and may be used to override the written value.
@@ -87,3 +89,13 @@ async function run(data: Input) {
   }
 }
 ```
+
+## Contributing
+
+Pull requests are welcome. See the [contribution guidelines](../../.github/contributing.md) for more information.
+
+## License
+
+MIT &copy; [Shopify](https://shopify.com/), see [LICENSE.md](LICENSE.md) for details.
+
+[![Shopify Logo Light](../../images/shopify-light.svg#gh-dark-mode-only)![Shopify Logo Dark](../../images/shopify-dark.svg#gh-light-mode-only)](<(https://www.shopify.com/)>)

--- a/packages/tokengate/README.md
+++ b/packages/tokengate/README.md
@@ -6,6 +6,24 @@ The `tokengate` component presents the gate requirements to unlock a reaction, a
 
 [View in Storybook](https://main--639b1f308693132693d9b82c.chromatic.com/?path=/story/tokengate-discount-locked--locked)
 
+## Installation
+
+Install the `shopify/tokengate` package.
+
+```bash
+yarn add @shopify/tokengate
+```
+
 ## Documentation
 
 For detailed documentation, [visit shopify.dev](https://shopify.dev/api/blockchain/components/tokengate).
+
+## Contributing
+
+Pull requests are welcome. See the [contribution guidelines](../../.github/contributing.md) for more information.
+
+## License
+
+MIT &copy; [Shopify](https://shopify.com/), see [LICENSE.md](LICENSE.md) for details.
+
+[![Shopify Logo Light](../../images/shopify-light.svg#gh-dark-mode-only)![Shopify Logo Dark](../../images/shopify-dark.svg#gh-light-mode-only)](<(https://www.shopify.com/)>)


### PR DESCRIPTION
## ℹ️ What is the context for these changes?

### **Summary**

To ensure we have a single source of truth for the documentation of our packages, we should link to the shopify.dev docs in the READMEs. 

**Pros**
- Single source of truth 
- Easier to maintain 
- Follows Shopify conventions 

## 🕹️ Demonstration

- [Connect wallet](https://github.com/Shopify/blockchain-components/blob/docs/link-to-dot-dev-in-readme/packages/connect-wallet/README.md) 
- [Gate context client](https://github.com/Shopify/blockchain-components/blob/docs/link-to-dot-dev-in-readme/packages/gate-context-client/README.md)

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] ~~Tested on mobile~~
- [x] Tested on multiple browsers
- [x] ~~Tested for accessibility~~
- [x] ~~Includes unit tests~~
- [x] ~~Updated relevant documentation for the changes (if necessary)~~
