### PR TITLE
[delegate-cash] Attribute vaults to order for delegate cash

### DIFF
--- a/.changeset/lovely-pants-hear.md
+++ b/.changeset/lovely-pants-hear.md
@@ -1,0 +1,6 @@
+---
+'@shopify/gate-context-client': minor
+'@shopify/connect-wallet': minor
+---
+
+[delegate-cash] Attributing vaults to the order when the delegations are fetched

--- a/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
@@ -22,11 +22,9 @@ export const fetchDelegations = createAsyncThunk(
       (delegation) => delegation.vault as Address,
     );
 
-    if (vaults.length) {
-      return thunkApi.fulfillWithValue({
-        address: walletAddress,
-        vaults,
-      });
-    }
+    return thunkApi.fulfillWithValue({
+      address: walletAddress,
+      vaults,
+    });
   },
 );

--- a/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
@@ -236,26 +236,24 @@ export const walletSlice = createSlice({
       throw new ConnectWalletError(errorMessage);
     });
     builder.addCase(fetchDelegations.fulfilled, (state, action) => {
-      if (action.payload) {
-        const {address, vaults} = action.payload;
+      const {address, vaults} = action.payload;
 
-        const connectedWallet = state.connectedWallets.find(
-          (wallet) =>
-            wallet.address.toLocaleLowerCase() === address.toLocaleLowerCase(),
-        );
+      const connectedWallet = state.connectedWallets.find(
+        (wallet) =>
+          wallet.address.toLocaleLowerCase() === address.toLocaleLowerCase(),
+      );
 
-        // Update wallet in 'connectedWallets' state
-        if (connectedWallet) {
-          connectedWallet.vaults = vaults;
-        }
+      // Update wallet in 'connectedWallets' state
+      if (connectedWallet) {
+        connectedWallet.vaults = vaults;
+      }
 
-        // Update wallet in 'activeWallet' state
-        if (
-          state.activeWallet?.address.toLocaleLowerCase() ===
-          address.toLocaleLowerCase()
-        ) {
-          state.activeWallet.vaults = vaults;
-        }
+      // Update wallet in 'activeWallet' state
+      if (
+        state.activeWallet?.address.toLocaleLowerCase() ===
+        address.toLocaleLowerCase()
+      ) {
+        state.activeWallet.vaults = vaults;
       }
     });
   },

--- a/packages/gate-context-client/src/cartAjaxApi/cartAjaxApi.ts
+++ b/packages/gate-context-client/src/cartAjaxApi/cartAjaxApi.ts
@@ -102,6 +102,7 @@ async function getAttributes<TGateContext>(
 
   const defaultAttributes = {
     'Wallet Address': gateContextInput.walletAddress,
+    ...(gateContextInput.vaults && {Vaults: gateContextInput.vaults}),
   };
 
   if (typeof shopify_gate_context !== 'undefined') {

--- a/packages/gate-context-client/src/types.ts
+++ b/packages/gate-context-client/src/types.ts
@@ -8,6 +8,7 @@ export interface GateContextWriteResponse<TRawResponse> {
 
 export interface GateContextInput {
   walletAddress: string;
+  vaults?: string[];
   walletVerificationMessage?: string;
   walletVerificationSignature?: string;
 }


### PR DESCRIPTION
## ℹ️ What is the context for these changes?

This PR is a part of the effort to implement delegate cash. 

This PR specifically adds a listener for when the delegations are fetched and then attributes the vault addresses to the order.

## 🕹️ Demonstration

**With  `enableDelegateCash` = `true`**
https://user-images.githubusercontent.com/18248358/226959260-a3c5fd5b-27b0-46b4-b8c9-ec2488ba45d7.mov

**With `enableDelegateCash` = `false`**
https://user-images.githubusercontent.com/18248358/226959334-af2d672d-73e6-444a-ba56-5655fc1a06fa.mov

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?

- Set up a delegate.cash account 
- Checkout this branch 
- Add console statements in `attributeOrder` to log the vault address(es) 
- Verify when you connect with your hot wallet, that the vault wallet address(es) are logged

Note: The writing to the cart cannot be tested in the playground as it needs to be tested in the online store. 

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] ~~Tested on mobile~~
- [x] ~~Tested on multiple browsers~~
- [x] ~~Tested for accessibility~~
- [x] Includes unit tests
- [x] ~~Updated relevant documentation for the changes (if necessary)~~ POST-MERGE
