### PR TITLE
[delegate-cash] Send vaults on onConnect callback

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -76,6 +76,7 @@ export default function ({serverArguments}: AppProps) {
         address: response.address,
         message: response.message,
         signature: response.signature,
+        vaults: response.vaults,
       });
     },
     onDisconnect: () => {

--- a/apps/playground/src/types/events.ts
+++ b/apps/playground/src/types/events.ts
@@ -34,6 +34,7 @@ export interface CheckIfWalletMeetsRequirementsEvent extends EventBusEvent {
     address: string;
     message: string;
     signature: string;
+    vaults?: string[];
   };
   response: {
     isUnlocked: boolean;

--- a/packages/connect-wallet/src/hooks/useConnectWallet/useConnectWalletCallbacks.ts
+++ b/packages/connect-wallet/src/hooks/useConnectWallet/useConnectWalletCallbacks.ts
@@ -17,6 +17,7 @@ export const useConnectWalletCallbacks = (props?: useConnectWalletProps) => {
     const listener = buildOnConnectMiddleware(({wallet}) => {
       publishEvent(eventNames.CONNECT_WALLET_ON_CONNECT_EVENT, {
         address: wallet.address,
+        vaults: wallet.vaults,
         connector: wallet.connectorId,
       });
       onConnect?.(wallet);


### PR DESCRIPTION
Implements support for [delegate.cash](https://delegate.cash) to allow linking a hot ("delegate") wallet which then looks up associated cold ("vault") wallet(s) that have been proven to be owned by the same entity.

We'll be doing this in different PRs based on the original PR: https://github.com/Shopify/blockchain-components/pull/13

## ℹ️ What is the context for these changes?
The `vaults` were already sent before, so this PR just makes this visible in the playground example.

## 🕹️ Demonstration
![image](https://user-images.githubusercontent.com/8977776/226952586-1f583e88-132c-4c16-9b9e-5cb37cc1c49d.png)



<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

- Run locally the playground `yarn dev`
- Connect a wallet with delegations
- See console log of `checkIfWalletMeetsRequirements` event that includes the vaults

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [x] Tested on multiple browsers
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
