### PR TITLE
Updates Tokengate reaction type

### DIFF
--- a/.changeset/khaki-worms-obey.md
+++ b/.changeset/khaki-worms-obey.md
@@ -1,0 +1,5 @@
+---
+'@shopify/tokengate': minor
+---
+
+The `reaction` prop for the Tokengate component was updated to prevent a discount from being provided to a discount with a type of `exclusive_access`.

--- a/packages/tokengate/src/types.ts
+++ b/packages/tokengate/src/types.ts
@@ -33,13 +33,20 @@ export interface RedemptionLimit {
   perToken: number;
 }
 
-export interface Reaction {
-  type: 'exclusive_access' | 'discount';
-  discount?: {
-    type: 'percentage' | 'amount';
+interface DiscountReaction {
+  type: 'discount';
+  discount: {
+    type: 'amount' | 'percentage';
     value: number;
   };
 }
+
+interface ExclusiveAccessReaction {
+  type: 'exclusive_access';
+  discount?: never;
+}
+
+export type Reaction = DiscountReaction | ExclusiveAccessReaction;
 
 export interface TokengateProps {
   connectButton: ReactNode;


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

This addresses a minor issue I noticed while writing documentation for the Tokengate package.

Prior to this change, the following was valid:

```tsx
  <Tokengate
    ...
    reaction={{
      type: 'discount'
    }}
  />
```

Notice that the reaction is missing a value for `reaction.discount`.

This change requires `reaction.discount` to be provided when reaction.type is `discount`. Additionally, it prevents `reaction.discount` from being provided as a value when `reaction.type` is `exclusive_access`.

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

🟢 Green CI

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [ ] ~Tested on multiple browsers~ N/A
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [x] Updated relevant documentation for the changes (if necessary)
