### PR TITLE
Refactoring `amount` to `fixedAmount`

### DIFF
--- a/.changeset/empty-books-sell.md
+++ b/.changeset/empty-books-sell.md
@@ -1,0 +1,9 @@
+---
+'@shopify/tokengate': major
+---
+
+Renaming the discount type from `amount` to `fixedAmount` in the `reaction` prop for the Tokengate component.
+
+This change was made to ensure naming consistency across the Shopify Blockchain ecosystem.
+
+To update your project to align with these changes, see the updated docs at https://shopify.dev/docs/api/blockchain/components/tokengate#reaction.

--- a/packages/tokengate/src/components/Tokengate/stories/playground/playground.stories.tsx
+++ b/packages/tokengate/src/components/Tokengate/stories/playground/playground.stories.tsx
@@ -16,7 +16,7 @@ const exclusiveReaction = ReactionFixture();
 const discountReaction = ReactionFixture({
   type: 'discount',
   discount: {
-    type: 'amount',
+    type: 'fixedAmount',
     value: 20,
   },
 });

--- a/packages/tokengate/src/fixtures/Reaction.ts
+++ b/packages/tokengate/src/fixtures/Reaction.ts
@@ -15,7 +15,7 @@ export const DiscountReactionFixture = (customProps?: DeepPartial<Reaction>) =>
     {
       type: 'discount',
       discount: {
-        type: 'amount',
+        type: 'fixedAmount',
         value: 10,
       },
     },

--- a/packages/tokengate/src/types.ts
+++ b/packages/tokengate/src/types.ts
@@ -65,7 +65,7 @@ export interface RedemptionLimit {
 interface DiscountReaction {
   type: 'discount';
   discount: {
-    type: 'amount' | 'percentage';
+    type: 'fixedAmount' | 'percentage';
     value: number;
   };
 }


### PR DESCRIPTION
## ℹ️ What is the context for these changes?

Our current implementation of the Reaction interface for discounts does not align with the naming conventions used by Shopify Functions. To maintain consistency, we need to update the property name `amount` to `fixedAmount` as per the Shopify Functions reference:

Shopify Functions reference: https://shopify.dev/api/functions/reference/product-discounts/graphql/common-objects/value

## 🕹️ Demonstration

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/18248358/227997924-075a4515-8e9e-4018-8915-77449b7fa57c.png">

## 🎩 How can this be tophatted?

- Checkout this branch
- Run `yarn storybook` 
- Verify that the reaction type is `fixedAmount` and the Tokengate card renders correctly

## ✅ Checklist
- [x] ~~Tested on mobile~~
- [x] ~~Tested on multiple browsers~~
- [x] ~~Tested for accessibility~~
- [x] Includes unit tests
- [x] ~~Updated relevant documentation for the changes (if necessary)~~ POST-MERGE
