### PR TITLE
[CONCEPT] :sparkles: Adds no segments state to Tokengate component.

### DIFF
--- a/.changeset/nasty-poems-develop.md
+++ b/.changeset/nasty-poems-develop.md
@@ -1,0 +1,7 @@
+---
+'@shopify/tokengate': patch
+---
+
+In this release, we added a "No Segment" display element to the Tokengate component which will be displayed under the following conditions (both must be met):
+- No conditions are provided in the requirements parameter, for example: `requirements={{conditions: [], logic: 'ANY'}}`
+- The component is not loading conditions, for example: `isLoading={false}`.

--- a/packages/tailwind-config/tailwind.config.js
+++ b/packages/tailwind-config/tailwind.config.js
@@ -73,9 +73,9 @@ module.exports = {
       qrcode: 'var(--sbc-border-radius-qrcode, 16px)',
       tokengate: 'var(--sbc-border-radius-tokengate, 8px)',
       // Add the DEFAULT value -- DEFAULT is a Tailwind convention
-      DEFAULT: defaultTheme.borderRadius.DEFAULT,
+      DEFAULT: '4px',
       full: defaultTheme.borderRadius.full,
-      lg: '0.5rem',
+      lg: '8px',
     },
     borderWidth: {
       'button-disabled': 'var(--sbc-border-width-button-disabled, 0px)',
@@ -85,6 +85,7 @@ module.exports = {
       popover: 'var(--sbc-border-width-popover, 0px)',
       tokengate: 'var(--sbc-border-width-tokengate, 1px)',
       0: '0',
+      DEFAULT: '1px',
     },
     boxShadow: {
       none: defaultTheme.boxShadow.none,
@@ -248,6 +249,9 @@ module.exports = {
         },
         '.border-tokengate': {
           'border-style': 'var(--sbc-border-style-tokengate, solid)',
+        },
+        '.border-dashed': {
+          'border-style': 'dashed',
         },
       });
     }),

--- a/packages/tokengate/src/components/Tokengate/stories/scenarios/NoSegments.stories.tsx
+++ b/packages/tokengate/src/components/Tokengate/stories/scenarios/NoSegments.stories.tsx
@@ -1,0 +1,22 @@
+import {Meta, StoryObj} from '@storybook/react';
+
+import {Template} from '../template';
+import {TokengatePropsNotConnectedFixture} from '../../../../fixtures';
+
+const TokengateStory: Meta<typeof Template> = {
+  title: 'Tokengate/NoSegments',
+  component: Template,
+};
+
+type Story = StoryObj<typeof Template>;
+
+export const NoSegments: Story = {
+  args: TokengatePropsNotConnectedFixture({
+    requirements: {
+      conditions: [],
+      logic: 'ANY',
+    },
+  }),
+};
+
+export default TokengateStory;

--- a/packages/tokengate/src/components/TokengateRequirements/TokengateRequirements.test.tsx
+++ b/packages/tokengate/src/components/TokengateRequirements/TokengateRequirements.test.tsx
@@ -1,0 +1,38 @@
+import {render} from '@testing-library/react';
+
+import {RequirementsFixture} from '../../fixtures';
+
+import {TokengateRequirements} from './TokengateRequirements';
+
+describe('TokengateRequirements', () => {
+  describe('No segment state', () => {
+    it('renders the no segment state when no conditions are provided', () => {
+      const element = render(
+        <TokengateRequirements requirements={{conditions: [], logic: 'ALL'}} />,
+      );
+
+      expect(element.queryByTestId('no-segments')).toBeDefined();
+    });
+
+    it('does not render the no segment state when conditions are provided', () => {
+      const requirements = RequirementsFixture();
+
+      const element = render(
+        <TokengateRequirements requirements={requirements} />,
+      );
+
+      expect(element.queryByTestId('no-segments')).toBeNull();
+    });
+
+    it('does not render the no segment state when conditions are not provided and the tokengate is loading', () => {
+      const element = render(
+        <TokengateRequirements
+          isLoading
+          requirements={{conditions: [], logic: 'ALL'}}
+        />,
+      );
+
+      expect(element.queryByTestId('no-segments')).toBeNull();
+    });
+  });
+});

--- a/packages/tokengate/src/components/TokengateRequirements/TokengateRequirements.tsx
+++ b/packages/tokengate/src/components/TokengateRequirements/TokengateRequirements.tsx
@@ -1,3 +1,5 @@
+import {Text} from 'shared';
+
 import {TokenList} from '../TokenList';
 import {useTranslation} from '../../hooks/useTranslation';
 import {Requirements, UnlockingToken} from '../../types';
@@ -23,6 +25,18 @@ const TokengateRequirements = ({
     hasMissingTokens,
     t,
   });
+
+  if (!requirements?.conditions.length && !isLoading) {
+    return (
+      <div className="sbc-py-5 sbc-text-center" data-testid="no-segments">
+        <div className="sbc-rounded sbc-border sbc-border-[#C9CCCF] sbc-p-3 sbc-border-dashed">
+          <Text className="sbc-capitalize" color="secondary" variant="bodyLg">
+            {t('noSegments')}
+          </Text>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <TokenList

--- a/packages/tokengate/src/providers/TokengateProvider/translations/en/TokengateRequirements.json
+++ b/packages/tokengate/src/providers/TokengateProvider/translations/en/TokengateRequirements.json
@@ -1,5 +1,6 @@
 {
   "conditionDescription": {
     "any": "Any token"
-  }
+  },
+  "noSegments": "No segments"
 }


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->
⚠️ Fixes: <!-- Paste a link to the relevant issue here (if one exists) -->

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

Adds a no segment state to the Tokengate component to indicate to the user when there are no conditions present for the Tokengate.

📖 Storybook

## 🕹️ Demonstration

<!--
  Showcase what you've created!

  - Before / after screenshots are appreciated for UI changes.
  - Videos may help better explain the changes being made in larger codebase changes.
  - If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

...

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

...

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [ ] ~Tested on multiple browsers~ N/A
- [ ] ~Tested for accessibility~ N/A
- [x] Includes unit tests
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
