### PR TITLE
🩹 Updated active.end text color and updated i18n options

### DIFF
--- a/.changeset/fluffy-clocks-listen.md
+++ b/.changeset/fluffy-clocks-listen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/tokengate': patch
+---
+
+This update adjusts the text color for the `active.end` prop and also removes the year from the text string when the year provided more than 90 days in the future and not the current year.

--- a/packages/tokengate/src/components/ButtonWrapper/ButtonWrapper.test.tsx
+++ b/packages/tokengate/src/components/ButtonWrapper/ButtonWrapper.test.tsx
@@ -50,4 +50,42 @@ describe('ButtonWrapper', () => {
       expect(element.queryByTestId('button-wrapper-text')).toBeNull();
     });
   });
+
+  describe('date formatting', () => {
+    it('renders a date without the year when it is the current year', () => {
+      const endDate = new Date();
+      endDate.setDate(endDate.getDate() + 14);
+      const year = endDate.getFullYear();
+
+      const element = render(
+        <ButtonWrapper
+          button={<DefaultButton />}
+          text={{key: 'activeEnd', value: endDate}}
+          translationNamespace="Buttons"
+        />,
+      );
+
+      expect(
+        element.queryByTestId('button-wrapper-text')?.innerText,
+      ).not.toContain(year.toString());
+    });
+
+    it('renders a date with the year when it is not the current year', () => {
+      const endDate = new Date();
+      endDate.setDate(endDate.getFullYear() + 1);
+      const year = endDate.getFullYear();
+
+      const element = render(
+        <ButtonWrapper
+          button={<DefaultButton />}
+          text={{key: 'activeEnd', value: endDate}}
+          translationNamespace="Buttons"
+        />,
+      );
+
+      expect(element.queryByTestId('button-wrapper-text')?.innerText).toContain(
+        year.toString(),
+      );
+    });
+  });
 });

--- a/packages/tokengate/src/components/ButtonWrapper/ButtonWrapper.tsx
+++ b/packages/tokengate/src/components/ButtonWrapper/ButtonWrapper.tsx
@@ -3,6 +3,8 @@ import {Button, Text} from 'shared';
 
 import {useTranslation} from '../../hooks/useTranslation';
 
+import {getYearFormatOption} from './utils';
+
 type TextColor = ComponentProps<typeof Text>['color'];
 
 interface Translation {
@@ -52,13 +54,11 @@ interface ButtonWrapperProps {
 }
 
 const FORMAT_OPTIONS = {
-  value: {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  },
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
 };
 
 export const ButtonWrapper = ({
@@ -77,7 +77,12 @@ export const ButtonWrapper = ({
           aria-label={t(button.label.key, {value: button.label.value})}
           label={t(button.label.key, {
             value: button.label.value,
-            formatParams: FORMAT_OPTIONS,
+            formatParams: {
+              value: {
+                ...FORMAT_OPTIONS,
+                year: getYearFormatOption(button.label.value),
+              },
+            },
           })}
           fullWidth
           size="Lg"
@@ -94,7 +99,15 @@ export const ButtonWrapper = ({
           data-testid="button-wrapper-text"
           variant="bodyMd"
         >
-          {t(text.key, {value: text.value, formatParams: FORMAT_OPTIONS})}
+          {t(text.key, {
+            value: text.value,
+            formatParams: {
+              value: {
+                ...FORMAT_OPTIONS,
+                year: getYearFormatOption(text.value),
+              },
+            },
+          })}
         </Text>
       ) : null}
     </div>

--- a/packages/tokengate/src/components/ButtonWrapper/utils.test.ts
+++ b/packages/tokengate/src/components/ButtonWrapper/utils.test.ts
@@ -1,0 +1,40 @@
+import {vi} from 'vitest';
+
+import {getYearFormatOption} from './utils';
+
+describe('ButtonWrapper/utils', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns undefined when the year provided is the current year', () => {
+    const date = new Date(2000, 1, 1, 13);
+    vi.setSystemTime(date);
+
+    const dateToUse = new Date(2000, 2, 2, 1).toISOString();
+
+    expect(getYearFormatOption(dateToUse)).toStrictEqual(undefined);
+  });
+
+  it('returns undefined when the date provided is in the following year and less than 3 months from current date', () => {
+    const date = new Date(2000, 9, 4);
+    vi.setSystemTime(date);
+
+    const dateToUse = new Date(2001, 0, 1).toISOString();
+
+    expect(getYearFormatOption(dateToUse)).toStrictEqual(undefined);
+  });
+
+  it('returns numeric when the date provided is in the following year and more than 3 months from current date', () => {
+    const date = new Date(2000, 8, 1);
+    vi.setSystemTime(date);
+
+    const dateToUse = new Date(2001, 0, 1).toISOString();
+
+    expect(getYearFormatOption(dateToUse)).toStrictEqual('numeric');
+  });
+});

--- a/packages/tokengate/src/components/ButtonWrapper/utils.ts
+++ b/packages/tokengate/src/components/ButtonWrapper/utils.ts
@@ -1,0 +1,29 @@
+export function getYearFormatOption(value: string): string | undefined {
+  try {
+    const currentDate = new Date();
+    const currentYear = currentDate.getFullYear();
+
+    // Convert the provided value into a date.
+    const providedDate = new Date(value);
+    const providedYear = providedDate.getFullYear();
+
+    // Get the difference in time from the provided date and the current date.
+    const differenceInTime = providedDate.getTime() - currentDate.getTime();
+
+    /**
+     * Get the number of days between the provided date and the current date.
+     *
+     * 1000 * 3600 * 24 is the number of ms in a day. With this, we can
+     * divide the time difference between the days to get the difference in days.
+     */
+    const differenceInDays = differenceInTime / (1000 * 3600 * 24);
+
+    if (differenceInDays > 90 && providedYear > currentYear) {
+      return 'numeric';
+    }
+
+    return undefined;
+  } catch {
+    return 'numeric';
+  }
+}

--- a/packages/tokengate/src/components/Tokengate/Tokengate.tsx
+++ b/packages/tokengate/src/components/Tokengate/Tokengate.tsx
@@ -48,7 +48,7 @@ export const Tokengate = (props: TokengateProps) => {
               ? {key: 'activeEnd', value: new Date(active.end)}
               : undefined
           }
-          textColor="primary"
+          textColor="secondary"
           translationNamespace="Buttons"
         />
       ),


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

During my pairing session with @Borahm we identified that the `active.end` text was rendering with the incorrect color. To address this, I've updated the color prop.

Additionally, we identified an issue where the year was being added to the date string when the year was not the current year. For the time being, this only works for the current year vs following year. It does not calculate based on 365 days. This means that December 31 and January 1 will show a year in the button. 

## 🕹️ Demonstration

<!--
  Showcase what you've created!

  - Before / after screenshots are appreciated for UI changes.
  - Videos may help better explain the changes being made in larger codebase changes.
  - If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

| Current year | Future year |
| - | - |
| <img width="1182" alt="Screenshot 2023-04-13 at 8 08 40 PM" src="https://user-images.githubusercontent.com/4250423/231915525-62b39cf2-fbcf-4912-ab8f-748b74016c15.png" /> |  <img width="1182" alt="Screenshot 2023-04-13 at 8 08 52 PM" src="https://user-images.githubusercontent.com/4250423/231915526-2161d2b5-571f-4786-a14f-17ea845d27e1.png" /> |

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

[📖 Storybook](https://639b1f308693132693d9b82c-vsmiiccyev.chromatic.com/)

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] ~Tested on mobile~ N/A
- [ ] ~Tested on multiple browsers~ N/A
- [ ] ~Tested for accessibility~ N/A
- [x] Includes unit tests
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
