### PR TITLE
:sparkles: Adds fetchingDelegates and fetchingEns state values

### DIFF
--- a/.changeset/breezy-dancers-eat.md
+++ b/.changeset/breezy-dancers-eat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/connect-wallet': minor
+---
+
+This release adds fetchingDelegates and fetchingEns state values which are exported via useConnectWallet.

--- a/packages/connect-wallet/src/hooks/useConnectWallet/useConnectWallet.ts
+++ b/packages/connect-wallet/src/hooks/useConnectWallet/useConnectWallet.ts
@@ -10,9 +10,13 @@ import {useConnectWalletCallbacks} from './useConnectWalletCallbacks';
 
 export function useConnectWallet(props?: useConnectWalletProps) {
   const {signing} = useAppSelector((state) => state.modal);
-  const {activeWallet, connectedWallets, pendingConnector} = useAppSelector(
-    (state) => state.wallet,
-  );
+  const {
+    activeWallet,
+    connectedWallets,
+    fetchingDelegates,
+    fetchingEns,
+    pendingConnector,
+  } = useAppSelector((state) => state.wallet);
 
   const connectWalletContext = useContext(ConnectWalletContext);
 
@@ -31,6 +35,8 @@ export function useConnectWallet(props?: useConnectWalletProps) {
     connecting: isConnecting,
     connectedWallets,
     disconnect,
+    fetchingDelegates,
+    fetchingEns,
     pendingConnector,
     signing,
     wallet: activeWallet,

--- a/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/delegateCash.ts
@@ -1,5 +1,7 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 import {DelegateCash} from 'delegatecash';
+// Use absolute path to resolve the issue of a dependency cycle.
+import {setFetchingDelegates} from 'src/slices/walletSlice/walletSlice';
 import {Address} from 'wagmi';
 
 export const fetchDelegations = createAsyncThunk(
@@ -17,6 +19,8 @@ export const fetchDelegations = createAsyncThunk(
         vaults: undefined,
       });
     }
+
+    thunkApi.dispatch(setFetchingDelegates(true));
 
     const delegateCash = new DelegateCash();
     const delegations = await delegateCash.getDelegationsByDelegate(

--- a/packages/connect-wallet/src/slices/walletSlice/fetchEns.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/fetchEns.ts
@@ -1,5 +1,7 @@
 import {createAsyncThunk} from '@reduxjs/toolkit';
 import {Address, Chain} from '@wagmi/core';
+// Use absolute path to resolve the issue of a dependency cycle.
+import {setFetchingEns} from 'src/slices/walletSlice/walletSlice';
 
 import {EthereumProviderType} from '../../types/provider';
 import {isDefaultProvider} from '../../utils/provider';
@@ -18,6 +20,8 @@ interface FetchEnsPayload {
 export const fetchEns = createAsyncThunk(
   'wallet/fetchEns',
   async ({address, chain, provider}: FetchEnsProps, thunkApi) => {
+    thunkApi.dispatch(setFetchingEns(true));
+
     // Check if the package initialization is using only the default provider.
     const isDefault = isDefaultProvider({chain, provider});
     if (isDefault) {

--- a/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
+++ b/packages/connect-wallet/src/slices/walletSlice/walletSlice.ts
@@ -13,6 +13,8 @@ import {fetchDelegations} from './delegateCash';
 export interface WalletSliceType {
   activeWallet?: Wallet;
   connectedWallets: Wallet[];
+  fetchingDelegates: boolean;
+  fetchingEns: boolean;
   message?: string;
   pendingConnector: SerializedConnector | undefined;
   pendingWallet: Wallet | undefined;
@@ -22,6 +24,8 @@ export interface WalletSliceType {
 export const initialState: WalletSliceType = {
   activeWallet: undefined,
   connectedWallets: [],
+  fetchingDelegates: false,
+  fetchingEns: false,
   message: undefined,
   pendingConnector: undefined,
   pendingWallet: undefined,
@@ -100,6 +104,12 @@ export const walletSlice = createSlice({
     setActiveWallet: (state, action: PayloadAction<Wallet | undefined>) => {
       state.activeWallet = action.payload;
     },
+    setFetchingDelegates: (state, action: PayloadAction<boolean>) => {
+      state.fetchingDelegates = action.payload;
+    },
+    setFetchingEns: (state, action: PayloadAction<boolean>) => {
+      state.fetchingEns = action.payload;
+    },
     setPendingConnector: (
       state,
       action: PayloadAction<SerializedConnector | undefined>,
@@ -141,6 +151,9 @@ export const walletSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(fetchEns.fulfilled, (state, action) => {
+      // Toggle the fetchingEns state.
+      state.fetchingEns = false;
+
       const {address, ensName} = action.payload;
 
       state.connectedWallets = state.connectedWallets.map((wallet) => {
@@ -236,6 +249,9 @@ export const walletSlice = createSlice({
       throw new ConnectWalletError(errorMessage);
     });
     builder.addCase(fetchDelegations.fulfilled, (state, action) => {
+      // Toggle the fetchingDelegates state.
+      state.fetchingDelegates = false;
+
       const {address, vaults} = action.payload;
 
       const connectedWallet = state.connectedWallets.find(
@@ -262,6 +278,8 @@ export const walletSlice = createSlice({
 export const {
   addWallet,
   setActiveWallet,
+  setFetchingDelegates,
+  setFetchingEns,
   setPendingConnector,
   setPendingWallet,
   removeWallet,


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

Adds `fetchingDelegates` and `fetchingEns` state values to detect when network events are in flight.

Experimenting with these values, but might also add an additional callback / rename the `onConnect` callback for `useConnectWallet` to `onWalletDataFetched` and re-utilize `onConnect` for when `setActiveWallet` is dispatched.

## 🕹️ Demonstration

<!--
  Showcase what you've created!

  - Before / after screenshots are appreciated for UI changes.
  - Videos may help better explain the changes being made in larger codebase changes.
  - If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

...

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

...

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [ ] Tested on mobile
- [ ] Tested on multiple browsers
- [ ] Tested for accessibility
- [ ] Includes unit tests
- [ ] Updated relevant documentation for the changes (if necessary)
