### PR TITLE
:bug: Addressed navigate back bug during signature flow

### DIFF
--- a/.changeset/spotty-walls-help.md
+++ b/.changeset/spotty-walls-help.md
@@ -1,0 +1,5 @@
+---
+'@shopify/connect-wallet': patch
+---
+
+Addressed a minor bug that would close the connection modal when navigating back during a signature flow.

--- a/packages/connect-wallet/src/hooks/useDisconnect.ts
+++ b/packages/connect-wallet/src/hooks/useDisconnect.ts
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 import {useDisconnect as wagmiUseDisconnect, useAccount} from 'wagmi';
 
 import {removeWallet, setActiveWallet} from '../slices/walletSlice';
+import {ConnectWalletError} from '../utils/error';
 
 import {useAppDispatch, useAppSelector} from './useAppState';
 
@@ -42,8 +43,10 @@ export const useDisconnect = () => {
       });
 
       if (!addressToDisconnect) {
-        throw new Error(
-          'There is not a connected wallet nor was a wallet address provided to the disconnect function.',
+        console.error(
+          new ConnectWalletError(
+            'There is not a connected wallet nor was a wallet address provided to the disconnect function.',
+          ),
         );
       }
 
@@ -76,5 +79,6 @@ export const useDisconnect = () => {
     },
     [connectedAddress, connectedWallets, disconnect, dispatch],
   );
+
   return {disconnect: handleDisconnect};
 };

--- a/packages/connect-wallet/src/slices/modalSlice/modalSlice.test.ts
+++ b/packages/connect-wallet/src/slices/modalSlice/modalSlice.test.ts
@@ -49,7 +49,11 @@ describe('modalSlice', () => {
 
   describe('goBack', () => {
     it('Resets the state to the initial state if the current route is "Signature"', () => {
-      expect(reducer(SIGNATURE_STATE, goBack())).toStrictEqual(initialState);
+      // The modal should still be open via {open: true}
+      expect(reducer(SIGNATURE_STATE, goBack())).toStrictEqual({
+        ...initialState,
+        open: true,
+      });
     });
 
     it('Goes back to the "Connect" route when the history is only 1 route deep', () => {

--- a/packages/connect-wallet/src/slices/modalSlice/modalSlice.ts
+++ b/packages/connect-wallet/src/slices/modalSlice/modalSlice.ts
@@ -39,7 +39,10 @@ export const modalSlice = createSlice({
     goBack: (state) => {
       // Reset the signature state if the current route is the Signing route.
       if (state.route === 'Signature') {
-        return initialState;
+        return {
+          ...initialState,
+          open: true,
+        };
       }
 
       if (state.history.length) {


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

Addresses a minor bug that prevented the user from seeing the connector screen inside of the modal after navigating back during the signature flow.

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

Using a local environment (or the linked Chromatic deployment from CI), you should do the following:
1. Click "Connect Wallet"
2. Click a connector (MetaMask will make the tophatting process much faster)
3. During signing, press the "Back" button in the top of the modal.
4. You **should** be redirected to the first screen within the modal which lists all available connectors.

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] Tested on mobile
- [x] Tested on multiple browsers
- [ ] ~Tested for accessibility~ N/A
- [x] Includes unit tests
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
