### PR TITLE
:bug: Fixes a minor bug related to modal close state cleanup

### DIFF
--- a/.changeset/tasty-books-reply.md
+++ b/.changeset/tasty-books-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/connect-wallet': patch
+---
+
+This patch addresses a minor bug relating to state cleanup when a modal is closed. Prior to this patch, an issue was present when closing the modal that would leave the state visible. This was an issue particularly when the user was connecting with a connector which was based on WalletConnect as the QR Code would be cleared. This addresses that by calling the `reset` state method which will clear the modal state and properly. In addition, functionality to handle disconnect events during signature flows was added for modal close events.

--- a/packages/connect-wallet/src/components/Modal/Modal.tsx
+++ b/packages/connect-wallet/src/components/Modal/Modal.tsx
@@ -38,7 +38,7 @@ import {ModalRoute} from '~/types/modal';
 
 export const Modal = () => {
   const [
-    {closeModal, goBack, navigate, open, route},
+    {goBack, navigate, open, reset, route},
     {pendingConnector, pendingWallet},
   ] = useStore((state) => [state.modal, state.wallet]);
   const {
@@ -60,9 +60,13 @@ export const Modal = () => {
 
   useEffect(() => {
     if (escPress && open) {
-      closeModal();
+      if (route === 'Signature') {
+        disconnect(pendingWallet?.address);
+      }
+
+      reset();
     }
-  }, [closeModal, escPress, open]);
+  }, [disconnect, escPress, open, pendingWallet?.address, reset, route]);
 
   const handleCloseModal = useCallback(() => {
     if (!open) return;
@@ -71,8 +75,8 @@ export const Modal = () => {
       disconnect(pendingWallet?.address);
     }
 
-    closeModal();
-  }, [closeModal, disconnect, open, pendingWallet?.address, route]);
+    reset();
+  }, [disconnect, open, pendingWallet?.address, reset, route]);
 
   const handleGoBack = useCallback(() => {
     if (route === 'Signature') {


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Prefix it with the type of PR, e.g. [feature|bugfix|chore]
  - Start with a verb, for example: Add, Delete, Improve, Fix
  - Prefix it with [WIP] while it’s a work in progress
-->

## ℹ️ What is the context for these changes?
<!-- Share what you're changing, and if necessary, the path you chose and why. -->

I noticed this bug while attempting to recreate another issue (which turned out to be a caching issue I suppose). The error is shown in the before example where selecting on a connecting option and then closing the modal would leave the state as-is at the time of the modal closing.

Now, the close event cleans up the modal state and resets it to restart the flow of connecting a wallet. This also addresses a weird UX where when an attempt to connect leads the user to the signature phase and when closed, the signature window does not re-open. Now, the package will manually disconnect the connected wallet, restarting the connection process.

## 🕹️ Demonstration

<!--
  Showcase what you've created!

  - Before / after screenshots are appreciated for UI changes.
  - Videos may help better explain the changes being made in larger codebase changes.
  - If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

<details><summary>Before (video)</summary>

https://github.com/Shopify/blockchain-components/assets/4250423/fd584b0f-9547-4b79-9142-341454de7af4

</details> 

<details><summary>After (video)</summary>

https://github.com/Shopify/blockchain-components/assets/4250423/6c274cd8-0b6a-4c0f-9059-f9c6685e5764

</details>

<!-- ℹ️ Delete the following for small / trivial changes -->

## 🎩 How can this be tophatted?
<!--
  1. Give as much information as needed to test the changes introduced in this PR.
  2. For changes that might require additional user testing, we recommend using CodeSandbox in conjunction with the `/snapit` command.
    - `/snapit` will create a snapshot version of the package which can be installed in a CodeSandbox environment that folks can use to test the changes introduced.
    - You can find out more information about `/snapit` and CodeSandbox usage in the Contributing guide.
-->

Use [Storybook](https://639b1f308693132693d9b82c-qfjiunougm.chromatic.com/) to test the changes here. You can test the current flow / experience using the [live storybook](https://main--639b1f308693132693d9b82c.chromatic.com/).

## ✅ Checklist
<!--
Tip: if any of these tasks are not relevant to this PR, mark them like this:
  - [x] ~Irrelevant task~ N/A, because <why it's not relevant to this PR>

If you add a custom task that will be completed after merging, mark it like this:
  - [ ] POST-MERGE: follow-up work

"N/A" and "POST-MERGE:" are special strings that tell task-list-checker to skip that task.
-->

- [x] Tested on mobile
- [x] Tested on multiple browsers
- [ ] ~Tested for accessibility~ N/A
- [ ] ~Includes unit tests~ N/A
- [ ] ~Updated relevant documentation for the changes (if necessary)~ N/A
